### PR TITLE
deps(n8n) Bump n8n to 2.25.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "n8n",
       "license": "MIT",
       "dependencies": {
-        "n8n": "^2.22.4"
+        "n8n": "^2.25.7"
       },
       "engines": {
         "node": "24"
@@ -41,12 +41,13 @@
       }
     },
     "node_modules/@ai-sdk/amazon-bedrock": {
-      "version": "4.0.108",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.108.tgz",
-      "integrity": "sha512-cVAzseR9OoSSL7966TMj2uUbDOL2e1LaH2JXrWvyMXQvF5Me2rPfzdA06k/vhYjP0DQq1uvsZPRojmg4ghiI9g==",
+      "version": "4.0.114",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.114.tgz",
+      "integrity": "sha512-s3ajs4hlAdb+5A58O423OY0zEcNfsjgGLv+GkbwZegjcvvfESyoH2CzZnG321Fjzr79nKpo7PQsVFxMZcWwFaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "3.0.79",
+        "@ai-sdk/anthropic": "3.0.82",
+        "@ai-sdk/openai": "3.0.69",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@smithy/eventstream-codec": "^4.0.1",
@@ -60,59 +61,14 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.79",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.79.tgz",
-      "integrity": "sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==",
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.82",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.82.tgz",
+      "integrity": "sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/amazon-bedrock/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.58",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.58.tgz",
-      "integrity": "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
-      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -122,12 +78,13 @@
       }
     },
     "node_modules/@ai-sdk/azure": {
-      "version": "3.0.66",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-3.0.66.tgz",
-      "integrity": "sha512-V3AjjnRMoKgBK/cxE8hb8/VxsBKV9bIdWwSZKE2mfEH0O599X1Pk6FwcOY+NM3e7sdyXhLjbIgaJCnZkdFH94g==",
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-3.0.72.tgz",
+      "integrity": "sha512-uGyTz78k7qhUrvwNhivvgKZCvLQeX7DpEZgpmFkOfTmWQT7e4q+pRSu3V0zc9BmUamc0OuCRl09bdeLkBlmnsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/openai": "3.0.65",
+        "@ai-sdk/deepseek": "2.0.36",
+        "@ai-sdk/openai": "3.0.69",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
       },
@@ -136,18 +93,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/azure/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@ai-sdk/cohere": {
@@ -166,22 +111,10 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/cohere/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/deepseek": {
-      "version": "2.0.35",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.35.tgz",
-      "integrity": "sha512-9DhYurbAvcurOEGN6u2myYDybrrzGfcrkG8hwmFjwTrePW6KCMggm0YxP7e8RkLYcQKqCEMgFlyEB4BM6EmiKg==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.36.tgz",
+      "integrity": "sha512-7K0iMfNCpJgU8sxpBb7iuxZdjRIJO2ooGH/DkDLU9FKFwhVYBHvL145AgtPjJjle1PGJLGBg5as3PMt24IBuVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -194,22 +127,10 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/deepseek/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.120",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.120.tgz",
-      "integrity": "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==",
+      "version": "3.0.127",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.127.tgz",
+      "integrity": "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -223,22 +144,10 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.79",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.79.tgz",
-      "integrity": "sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==",
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.80.tgz",
+      "integrity": "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -249,18 +158,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@ai-sdk/groq": {
@@ -279,18 +176,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/groq/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/mistral": {
       "version": "3.0.37",
       "resolved": "https://registry.npmjs.org/@ai-sdk/mistral/-/mistral-3.0.37.tgz",
@@ -307,22 +192,10 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/mistral/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.65",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.65.tgz",
-      "integrity": "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==",
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.69.tgz",
+      "integrity": "sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.10",
@@ -335,22 +208,26 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.48.tgz",
+      "integrity": "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "json-schema": "^0.4.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -376,22 +253,10 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@ai-sdk/xai": {
-      "version": "3.0.92",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-3.0.92.tgz",
-      "integrity": "sha512-yqRMdEVfSkZCXs5mqeKfYOuQElo93igwz/4zWbYkhZWAW7tDh+5uqRef6MtQVYF/bTC1EsdbeO9DtsOtAZMOLA==",
+      "version": "3.0.93",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-3.0.93.tgz",
+      "integrity": "sha512-HxazLIcSTgI0UQoq6ua0rcSR8+eXuNy0Qh4jkCY9EAWedYn6CQ0XD/j34U4/JYtO738xJdY+tE95okdqWqXkHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.48",
@@ -403,34 +268,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/openai-compatible": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.48.tgz",
-      "integrity": "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -695,21 +532,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.4.tgz",
+      "integrity": "sha512-Pt1JEVLu02jTWzpcUzUHciiWScyZg3JpHCTB1h9DtDPWY3dBufBnFJAevVHali/bAkmMdMhYUD8tH/VvPuBkUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums/node_modules/@aws-sdk/core": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums/node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.1054.0.tgz",
-      "integrity": "sha512-buKSmh/GJNvP9r9Ghx9nl6QPju3zRvLgX3WNKJztDWxoEe1WJAkL0Kh37P3JMQ2SWxx+JrSKQvuwF/4jY60mkQ==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.1065.0.tgz",
+      "integrity": "sha512-QJdLzsVWMA38y5dxEZcj1St7i1JVinQtBabEQlmv7WWzcTKG7HjPevArRl+InIlMrzEX41s8MnCOmp1n4kbA9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -717,17 +605,17 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -736,15 +624,15 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -752,17 +640,17 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -770,23 +658,23 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -794,21 +682,21 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -816,15 +704,15 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -832,17 +720,17 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -850,16 +738,16 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -867,20 +755,20 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -888,16 +776,16 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -905,12 +793,12 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agent-runtime/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -918,468 +806,617 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1054.0.tgz",
-      "integrity": "sha512-APBAWir5vHzUWZ11bHfG3fXJ9t359bcwehwLTScpiYwmUydw7DqH76RAbtiYSstrV76hJ1v3pHM8pGk//E/0uw==",
+      "version": "3.938.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.938.0.tgz",
+      "integrity": "sha512-LMr4eWwET3mCQKsk3rbKKvUQCMuyeqdqNuJ8+NGVv2CgSdnlW9Dl6IMXiF7yGDgQaQxlGRthp+EogNTC562NZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/eventstream-handler-node": "^3.972.17",
-        "@aws-sdk/middleware-eventstream": "^3.972.13",
-        "@aws-sdk/middleware-websocket": "^3.972.22",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-node": "3.936.0",
+        "@aws-sdk/eventstream-handler-node": "3.936.0",
+        "@aws-sdk/middleware-eventstream": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/middleware-websocket": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/token-providers": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.936.0.tgz",
+      "integrity": "sha512-0G73S2cDqYwJVvqL08eakj79MZG2QRaB56Ul8/Ps9oQxllr7DMI1IQ/N3j3xjxgpq/U36pkoFZ8aK1n7Sbr3IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.936.0.tgz",
+      "integrity": "sha512-eGJ2ySUMvgtOziHhDRDLCrj473RJoL4J1vPjVM3NrKC/fF3/LoHjkut8AAnKmrW6a2uTzNKubigw8dEnpmpERw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.936.0.tgz",
+      "integrity": "sha512-dKajFuaugEA5i9gCKzOaVy9uTeZcApE+7Z5wdcZ6j40523fY1a56khDAUYkCfwqa7sHci4ccmxBkAo+fW1RChA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.936.0.tgz",
+      "integrity": "sha512-5FguODLXG1tWx/x8fBxH+GVrk7Hey2LbXV5h9SFzYCx/2h50URBm0+9hndg0Rd23+xzYe14F6SI9HA9c1sPnjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.936.0.tgz",
+      "integrity": "sha512-TbUv56ERQQujoHcLMcfL0Q6bVZfYF83gu/TjHkVkdSlHPOIKaG/mhE2XZSQzXv1cud6LlgeBbfzVAxJ+HPpffg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-env": "3.936.0",
+        "@aws-sdk/credential-provider-http": "3.936.0",
+        "@aws-sdk/credential-provider-login": "3.936.0",
+        "@aws-sdk/credential-provider-process": "3.936.0",
+        "@aws-sdk/credential-provider-sso": "3.936.0",
+        "@aws-sdk/credential-provider-web-identity": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.936.0.tgz",
+      "integrity": "sha512-8DVrdRqPyUU66gfV7VZNToh56ZuO5D6agWrkLQE/xbLJOm2RbeRgh6buz7CqV8ipRd6m+zCl9mM4F3osQLZn8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.936.0.tgz",
+      "integrity": "sha512-rk/2PCtxX9xDsQW8p5Yjoca3StqmQcSfkmD7nQ61AqAHL1YgpSQWqHE+HjfGGiHDYKG7PvE33Ku2GyA7lEIJAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "3.936.0",
+        "@aws-sdk/credential-provider-http": "3.936.0",
+        "@aws-sdk/credential-provider-ini": "3.936.0",
+        "@aws-sdk/credential-provider-process": "3.936.0",
+        "@aws-sdk/credential-provider-sso": "3.936.0",
+        "@aws-sdk/credential-provider-web-identity": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.936.0.tgz",
+      "integrity": "sha512-GpA4AcHb96KQK2PSPUyvChvrsEKiLhQ5NWjeef2IZ3Jc8JoosiedYqp6yhZR+S8cTysuvx56WyJIJc8y8OTrLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.936.0.tgz",
+      "integrity": "sha512-wHlEAJJvtnSyxTfNhN98JcU4taA1ED2JvuI2eePgawqBwS/Tzi0mhED1lvNIaWOkjfLd+nHALwszGrtJwEq4yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/client-sso": "3.936.0",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/token-providers": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.936.0.tgz",
+      "integrity": "sha512-v3qHAuoODkoRXsAF4RG+ZVO6q2P9yYBT4GMpMEfU9wXVNn7AIfwZgTwzSUfnjNiGva5BKleWVpRpJ9DeuLFbUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.936.0.tgz",
+      "integrity": "sha512-YB40IPa7K3iaYX0lSnV9easDOLPLh+fJyUDF3BH8doX4i1AOSsYn86L4lVldmOaSX+DwiaqKHpvk4wPBdcIPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.936.0.tgz",
+      "integrity": "sha512-eyj2tz1XmDSLSZQ5xnB7cLTVKkSJnYAEoNDSUNhzWPxrBDYeJzIbatecOKceKCU8NBf8gWWZCK/CSY0mDxMO0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.936.0.tgz",
+      "integrity": "sha512-vvw8+VXk0I+IsoxZw0mX9TMJawUJvEsg3EF7zcCSetwhNPAU8Xmlhv7E/sN/FgSmm7b7DsqKoW6rVtQiCs1PWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/nested-clients": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.936.0.tgz",
+      "integrity": "sha512-XOEc7PF9Op00pWV2AYCGDSu5iHgYjIO53Py2VUQTIvP7SRCaCsXmA33mjBvC2Ms6FhSyWNa4aK4naUGIz0hQcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1054.0.tgz",
-      "integrity": "sha512-B3R1BnF9MtyAyIhI875geixK4SJ1dXwWjf8McBMyMkctaXdvGx5O4YD7MPxGPtbmExrW4tDp6h4wQbDJDLZumw==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.808.0.tgz",
+      "integrity": "sha512-M9pdFQ+Efl1O4No6R7uMEOkidKVUiNsmN13EyzuIOGech9g+RF+LgDn3n8+PuC7EIgndQVe6sQ6w39sPQdBkww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-kendra": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kendra/-/client-kendra-3.1054.0.tgz",
-      "integrity": "sha512-pIM4br1YF6JzzmwPKP/hHXV+OYd6E0FQ18DwmG/j4ayuwmgxuQqemvyXYb6saNwLoc7RuYLzKu74C2E/bnDAVQ==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kendra/-/client-kendra-3.1065.0.tgz",
+      "integrity": "sha512-/5SwiGP4KvlAE3mfMlIN/x+W0tP43+K5QU/vu7LPdIsBn65+T0ZAA1yGqlKPZsVlsLnEBzt/mDRdNjgOdX68nA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1387,17 +1424,17 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1406,15 +1443,15 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1422,17 +1459,17 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1440,23 +1477,23 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1464,21 +1501,21 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1486,15 +1523,15 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1502,17 +1539,17 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1520,16 +1557,16 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1537,20 +1574,20 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1558,16 +1595,16 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1575,12 +1612,12 @@
       }
     },
     "node_modules/@aws-sdk/client-kendra/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1588,28 +1625,24 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1054.0.tgz",
-      "integrity": "sha512-2ue7uVqaHYX4rytkcrLySYU/m/ZlRbL8KojWefbR24B0/TcFkqN2IovpBFrnmla/dtZAn9eVSlhHeEddOghZ5w==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1065.0.tgz",
+      "integrity": "sha512-KtCpg2vihUjhUpqpsZIcB6Dm1hv9lRn5hWwU6hXtYfSQionFD/dB/gTwgyn9AHX6eGiCFqHfjIZwETz5Cz4RWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.16",
-        "@aws-sdk/middleware-expect-continue": "^3.972.13",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.22",
-        "@aws-sdk/middleware-location-constraint": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.43",
-        "@aws-sdk/middleware-ssec": "^3.972.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.29",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.50",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1617,17 +1650,17 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1636,15 +1669,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1652,17 +1685,17 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1670,23 +1703,23 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1694,21 +1727,21 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1716,15 +1749,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1732,17 +1765,17 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1750,16 +1783,16 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1767,20 +1800,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1788,16 +1821,16 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1805,12 +1838,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1818,20 +1851,20 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker/-/client-sagemaker-3.1054.0.tgz",
-      "integrity": "sha512-w8N6X1nki89KFFEiTnj/hj5ZMqQAx7WKj1izmwZNs+qfz3yTyPppImh1bCIB7K4Bj8B103wIixzxjJsoEIE/XQ==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker/-/client-sagemaker-3.1065.0.tgz",
+      "integrity": "sha512-m0JxViZrQR/kX3gl0sENOHcVRBzvCiEZxQBWKdMaS8lSBIRniE6IIrPeuKhjLVb4+IIwXueDLr1MzTApd4gLDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1839,17 +1872,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1858,15 +1891,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1874,17 +1907,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1892,23 +1925,23 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1916,21 +1949,21 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1938,15 +1971,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1954,17 +1987,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1972,16 +2005,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1989,20 +2022,20 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2010,16 +2043,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2027,12 +2060,12 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2212,86 +2245,20 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
-      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.37.tgz",
-      "integrity": "sha512-f8ZRPoATqSVS1LW19KwiWn2/BSTdylXPznAjDI2r7d3+RT880/yRT9uBQhPE+Ba986LiMRvg1AhmFYDwNLk/0A==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.808.0.tgz",
+      "integrity": "sha512-AbsD/qHyQmyZ+CqJNOaGlnwZaXu8HfndfEiLsIJU/dIf9Wbt7ZtsHSAI/x78awxGohDneMZ6c5vuaRGYL7Z04g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/client-cognito-identity": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
@@ -2356,16 +2323,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.44.tgz",
-      "integrity": "sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
+      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2373,17 +2340,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -2392,20 +2359,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2413,12 +2380,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2502,270 +2469,71 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1054.0.tgz",
-      "integrity": "sha512-/tK0QmOL1vUqOgqRMLTJlvHRAp+7GTfdPgrfgD5T0WBmExdlaFsVwzR7mUQlmYoY8mExqoRH4UEt2I3snsMLrg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.808.0.tgz",
+      "integrity": "sha512-JJvY/gcet+tFw7dGifhTMJ2jfLXCJBR2Tu2rY/ePi+HVUrR//TnWmcm8qGvT1nWiCQ7w9NEhMlJgqKEIM/MkVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.1054.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.37",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/client-cognito-identity": "3.808.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.808.0",
+        "@aws-sdk/credential-provider-env": "3.808.0",
+        "@aws-sdk/credential-provider-http": "3.808.0",
+        "@aws-sdk/credential-provider-ini": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/credential-provider-process": "3.808.0",
+        "@aws-sdk/credential-provider-sso": "3.808.0",
+        "@aws-sdk/credential-provider-web-identity": "3.808.0",
+        "@aws-sdk/nested-clients": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-      "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-      "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-      "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-      "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-      "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-      "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-      "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-      "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-      "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
-      "integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.936.0.tgz",
+      "integrity": "sha512-4zIbhdRmol2KosIHmU31ATvNP0tkJhDlRj9GuawVJoEnMvJA1pd2U3SRdiOImJU3j8pT46VeS4YMmYxfjGHByg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/eventstream-codec": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1054.0.tgz",
-      "integrity": "sha512-cnEZOTWnfRDS5wpCT6yVgQai16R+qhC5E9p1wfmjwj4H4YfI0dVq7I2zUZjUjb4Pfy0dIziCuwQg1jEVQzW/Ew==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1065.0.tgz",
+      "integrity": "sha512-0eEVoAWuvob9BkiKc/jtFPaOQYR7hbW6xioTe3b1U1WpwyVLKO6KROdm1zpMC7k5EOpVDhdFXkqZvFSCJuc4Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -2775,159 +2543,77 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1054.0"
+        "@aws-sdk/client-s3": "^3.1065.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.16.tgz",
-      "integrity": "sha512-FhasMTBDBmMN7EEa1hUeHwo5p5Mv3Dm8w0VEbdXX/6ola/uyhRuJt8zGkH09mLTmab20USTzEpPqyqEoe1MqNg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
+      "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
-      "integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.936.0.tgz",
+      "integrity": "sha512-XQSH8gzLkk8CDUDxyt4Rdm9owTpRIPdtg2yw9Y2Wl5iSI55YQSiC3x8nM3c4Y4WqReJprunFPK225ZUDoYCfZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.13.tgz",
-      "integrity": "sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.804.0.tgz",
+      "integrity": "sha512-YW1hySBolALMII6C8y7Z0CRG2UX1dGJjLEBNFeefhO/xP7ZuE1dvnmfJGaEuBMnvc3wkRS63VZ3aqX6sevM1CA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.22.tgz",
-      "integrity": "sha512-ot1kZ1JGHUxcXPOARhej/n/+Odfx9VPt60pNrUq8Lf/U2blIF3+uj5v56gw76VD70dZvrfeLNo9jKz6pQJfOlA==",
+      "version": "3.974.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.29.tgz",
+      "integrity": "sha512-ALTHDXk6YWVDfAWIHzXyaTZ82QFoMWhHENXlO61lv4ZqSMl3cvh2s0ZVOS89qbtw9LRJhIDoZaaC9FYo/Z4KLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/crc64-nvme": "^3.972.9",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/checksums": "^3.1000.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2950,30 +2636,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
-      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.804.0.tgz",
+      "integrity": "sha512-AMtKnllIWKgoo7hiJfphLYotEwTERfjVMO2+cKAncz9w1g+bnYhHxiVhJJoR94y047c06X4PU5MsTxvdQ73Znw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
@@ -3006,16 +2679,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.43.tgz",
-      "integrity": "sha512-CBmixMY36JdAdt9ALgm7yVlvOXGUCHt9Z2kn5p9XVO5StO6HCH+cayV7YYV1CDLsXvVyebaXgBmif9wHoxCeNA==",
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.50.tgz",
+      "integrity": "sha512-yOXn9mmJQQODpbmwQB224IX1PLLneyqInX2Fv2nEmSHWpJj54nrzdrUT1TGQk/s8mr+XPssDQy1at/8GS4EFVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3023,17 +2696,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -3042,12 +2715,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3055,30 +2728,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
-      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.804.0.tgz",
+      "integrity": "sha512-Tk8jK0gOIUBvEPTz/wwSlP1V70zVQ3QYqsLPAjQRMO6zfOK9ax31dln3MgKvFDJxBydS2tS3wsn53v+brxDxTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
@@ -3100,53 +2760,38 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.22.tgz",
-      "integrity": "sha512-aumo6pYnvD1/eda3R0UDkRVecwxsuW4zTZLdjbHg7NqYMKmy7vK0bM3NGJzCD+Ys8iqCC7EeDU4LuWVIsXvL+A==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.936.0.tgz",
+      "integrity": "sha512-bPe3rqeugyj/MmjP0yBSZox2v1Wa8Dv39KN+RxVbQroLO8VUitBo6xyZ0oZebhZ5sASwSg58aDcMlX0uFLQnTA==",
+      "deprecated": "Please update your @aws-sdk client to a more recent version, such as https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.982.0, if using browser-based WebSocket bidirectional streaming.",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-format-url": "3.936.0",
+        "@smithy/eventstream-codec": "^4.2.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-websocket/node_modules/@aws-sdk/core": {
-      "version": "3.974.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-      "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-websocket/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
@@ -3269,14 +2914,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.29.tgz",
-      "integrity": "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==",
+      "version": "3.996.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
+      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3284,12 +2929,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3492,6 +3137,34 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
+      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.873.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.873.0.tgz",
@@ -3550,12 +3223,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -3585,16 +3258,19 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
@@ -3606,9 +3282,9 @@
       }
     },
     "node_modules/@azure-rest/core-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
-      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.1.tgz",
+      "integrity": "sha512-KzI10qnkWTsVS2yRBUdc8NLUJ1rOm+292mYs7Pe9wqAj/jv4bRskVm1l8XkKeVTN0OCQtrU5RG0Yhjbz1Wmg7g==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -3862,16 +3538,19 @@
       }
     },
     "node_modules/@azure/core-xml/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/@azure/identity": {
       "version": "4.13.0",
@@ -3957,26 +3636,25 @@
       }
     },
     "node_modules/@azure/keyvault-keys": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.0.tgz",
-      "integrity": "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.2.tgz",
+      "integrity": "sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/core-client": "^2.3.3",
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
         "@azure/core-lro": "^2.7.2",
         "@azure/core-paging": "^1.6.2",
         "@azure/core-rest-pipeline": "^1.19.0",
         "@azure/core-tracing": "^1.2.0",
         "@azure/core-util": "^1.11.0",
-        "@azure/keyvault-common": "^2.0.0",
+        "@azure/keyvault-common": "^2.1.0",
         "@azure/logger": "^1.1.4",
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/keyvault-keys/node_modules/@azure/abort-controller": {
@@ -4177,9 +3855,9 @@
       }
     },
     "node_modules/@browserbasehq/sdk": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.12.0.tgz",
-      "integrity": "sha512-bwgVjjYc4O54Cvkc5POfZUv0Gl92n1nNfAPueRLQVFsDoPRTw0FS8wKo9/bQCQuyzAg9+RQUDqvUC241ogLRTQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.14.0.tgz",
+      "integrity": "sha512-DqVfjlgt74vPWfWiCp4VPtiMNJxg2yBZwio2uOfnpV1aJM0OWZR4AJrt/4df+xgQQ/guRpds5do41ycrDaYt3w==",
       "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -4397,30 +4075,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/@dsnp/parquetjs": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.8.7.tgz",
-      "integrity": "sha512-3DkkN3FKJ++BQy8PE3LONoVSVBONG7hld9D+VqBp1Dcfw2PGSnWyg20NET5cJkiygWK2y2H1ra8GWk3yixzuuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-s3": "^3.750.0",
-        "@types/node-int64": "^0.4.32",
-        "@types/thrift": "^0.10.17",
-        "@zenfs/core": "^1.11.2",
-        "brotli-wasm": "^3.0.1",
-        "bson": "6.10.3",
-        "int53": "^1.0.0",
-        "long": "^5.3.1",
-        "node-int64": "^0.4.0",
-        "snappyjs": "^0.7.0",
-        "thrift": "0.21.0",
-        "varint": "^6.0.0",
-        "xxhash-wasm": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.18.2"
-      }
-    },
     "node_modules/@ewoudenberg/difflib": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@ewoudenberg/difflib/-/difflib-0.1.0.tgz",
@@ -4518,9 +4172,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
-      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -4536,8 +4190,7 @@
         "mime": "^3.0.0",
         "p-limit": "^3.0.1",
         "retry-request": "^7.0.0",
-        "teeny-request": "^9.0.0",
-        "uuid": "^8.0.0"
+        "teeny-request": "^9.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -4566,25 +4219,18 @@
       }
     },
     "node_modules/@google-cloud/storage/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "dependencies": {
+        "anynum": "^1.0.0"
       }
     },
     "node_modules/@google/genai": {
@@ -4721,9 +4367,9 @@
       "license": "ISC"
     },
     "node_modules/@ibm-cloud/watsonx-ai": {
-      "version": "1.7.12",
-      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.12.tgz",
-      "integrity": "sha512-++tkoj1yLKNMeS+EPC/cvVYQZbyLAUGdDy/QeUObhRYSQmENDnCcA3Y1qquBH6XcPLXw7sQCQZCwFfhCTrvJow==",
+      "version": "1.7.13",
+      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.13.tgz",
+      "integrity": "sha512-xduIj2subUermAwmz3mz5LXlLfUVyN+NwzswsIkl5EmU4t4VJ/040gtdbsjmwWrwKBA6xPxTt3i1NAEaFVvahA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -5004,15 +4650,6 @@
         "@langchain/core": "^1.1.41"
       }
     },
-    "node_modules/@langchain/anthropic/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@langchain/aws": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@langchain/aws/-/aws-1.0.3.tgz",
@@ -5088,27 +4725,6 @@
         "@langchain/core": "^1.1.38"
       }
     },
-    "node_modules/@langchain/classic/node_modules/openai": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@langchain/classic/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -5121,15 +4737,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/classic/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@langchain/cohere": {
@@ -5180,15 +4787,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@langchain/core/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@langchain/google-common": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/@langchain/google-common/-/google-common-2.1.24.tgz",
@@ -5232,9 +4830,9 @@
       }
     },
     "node_modules/@langchain/google-gauth/node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -5260,9 +4858,9 @@
       }
     },
     "node_modules/@langchain/google-gauth/node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -5375,12 +4973,12 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.4.tgz",
+      "integrity": "sha512-1y5MgZ0gXXrtmoy56e3kaBChI3GwFPIKl27xkrHwN+VE/3iUsyr9gO3Jtp7kdKAe6diZGbcas5bdC/r0yUwTZA==",
       "license": "MIT",
       "dependencies": {
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -5390,17 +4988,16 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
@@ -5471,15 +5068,6 @@
         "@langchain/langgraph": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@langchain/mcp-adapters/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@langchain/mistralai": {
@@ -5574,36 +5162,6 @@
         "@langchain/core": "^1.1.39"
       }
     },
-    "node_modules/@langchain/openai/node_modules/openai": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/openai/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@langchain/pinecone": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@langchain/pinecone/-/pinecone-1.0.1.tgz",
@@ -5636,9 +5194,9 @@
       }
     },
     "node_modules/@langchain/protocol": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
       "license": "MIT"
     },
     "node_modules/@langchain/qdrant": {
@@ -7075,15 +6633,6 @@
         "zod-to-json-schema": "^3.24.1"
       }
     },
-    "node_modules/@mistralai/mistralai/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
@@ -7225,15 +6774,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
@@ -7355,28 +6895,42 @@
         "node": ">=18.12.1"
       }
     },
+    "node_modules/@n8n_io/riot-tmpl": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
+      "integrity": "sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eslint-config-riot": "^1.0.0"
+      }
+    },
     "node_modules/@n8n/agents": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/agents/-/agents-0.9.0.tgz",
-      "integrity": "sha512-drLfuL43lBtiltgVad2bFCt8cngG34BmzDZnoOxaqU0OCfT4CVlk0Dzkg0TfMTALL9CCWLUJV5P9rnXaSUMwng==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@n8n/agents/-/agents-0.11.0.tgz",
+      "integrity": "sha512-uJ1r0w3OrcL7ZU9x54oNXfG0otQJ4Vx/5dQNT24+TCBsIZ2Fil1QKhzB6bGHzbk7tmoo3gWRpKhyp8DLLzrl2A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ai-sdk/amazon-bedrock": "^4.0.95",
-        "@ai-sdk/anthropic": "3.0.58",
-        "@ai-sdk/azure": "^3.0.54",
-        "@ai-sdk/cohere": "^3.0.30",
-        "@ai-sdk/deepseek": "^2.0.29",
-        "@ai-sdk/gateway": "^3.0.104",
-        "@ai-sdk/google": "^3.0.43",
-        "@ai-sdk/groq": "^3.0.35",
-        "@ai-sdk/mistral": "^3.0.30",
-        "@ai-sdk/openai": "^3.0.41",
-        "@ai-sdk/provider-utils": "^4.0.21",
-        "@ai-sdk/xai": "^3.0.67",
+        "@ai-sdk/amazon-bedrock": "^4.0.113",
+        "@ai-sdk/anthropic": "^3.0.81",
+        "@ai-sdk/azure": "^3.0.70",
+        "@ai-sdk/cohere": "^3.0.36",
+        "@ai-sdk/deepseek": "^2.0.35",
+        "@ai-sdk/gateway": "^3.0.125",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/groq": "^3.0.39",
+        "@ai-sdk/mistral": "^3.0.37",
+        "@ai-sdk/openai": "^3.0.68",
+        "@ai-sdk/openai-compatible": "^2.0.48",
+        "@ai-sdk/provider-utils": "^4.0.27",
+        "@ai-sdk/xai": "^3.0.93",
+        "@daytonaio/sdk": "0.175.0",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@n8n/ai-utilities": "0.17.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/sandbox-client": "0.0.4",
+        "@n8n/utils": "1.34.0",
         "@openrouter/ai-sdk-provider": "^2.8.0",
-        "ai": "^6.0.116",
+        "ai": "^6.0.197",
         "ajv": "^8.18.0",
         "yaml": "2.8.3",
         "zod": "3.25.67"
@@ -7402,19 +6956,28 @@
         }
       }
     },
+    "node_modules/@n8n/agents/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@n8n/ai-node-sdk": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.14.0.tgz",
-      "integrity": "sha512-QGaagbU3KzZIDngcjTxV6Ei1nQeVx7oMqTH1LhLlPJvxX0sWFRpavMRNGbSofmZoiFnXMHvLtgyc8n6I6P137w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.16.0.tgz",
+      "integrity": "sha512-2Xf8yTRw53ec1tN9kuclU/9svArl8jUGIOmg8hVmpOOeeLkkDXkpjBBoQcsKn5UpB0BQHcQIqKvi7CBgYbEj5Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/ai-utilities": "0.17.0"
+        "@n8n/ai-utilities": "0.19.0"
       }
     },
     "node_modules/@n8n/ai-utilities": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.17.0.tgz",
-      "integrity": "sha512-MnCBMvXxHX9GtdjheqaO9DPGIbC5xTdyLSMMWfYLXK2xldUHZqcmeRHeAYnlg2rn9VkKFOqsn7T+h1ljF12KvA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.19.0.tgz",
+      "integrity": "sha512-XQpPUUtX+GqwYWa83xUmQkhsCYT3rRRlD2BcfviwSPDuVHnzU3iGcEVN2CPhAXFVorzVN/EDuOiKBGcTc0kmbA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@langchain/classic": "1.0.27",
@@ -7422,16 +6985,17 @@
         "@langchain/core": "1.1.41",
         "@langchain/openai": "1.4.4",
         "@langchain/textsplitters": "1.0.1",
-        "@n8n/config": "2.22.0",
-        "@n8n/typescript-config": "1.4.0",
-        "@n8n/utils": "1.32.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/typescript-config": "1.5.0",
+        "@n8n/utils": "1.34.0",
+        "@thednp/dommatrix": "^2.0.12",
         "https-proxy-agent": "7.0.6",
         "js-tiktoken": "1.0.21",
         "langchain": "1.2.30",
         "pdf-parse": "2.4.5",
         "proxy-from-env": "^1.1.0",
         "tmp-promise": "3.0.3",
-        "undici": "^6.21.0",
+        "undici": "^6.24.0",
         "zod": "3.25.67",
         "zod-to-json-schema": "3.23.3"
       },
@@ -7489,6 +7053,7 @@
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.27.tgz",
       "integrity": "sha512-s2U3w7QV7QpkFtY1eZMni4poz+nKLFclpDi3a7hUbZ67ttsGaU9WkZ2BiLuzLIs+IFaUvON/KcGkE8EqAl9aPA==",
+      "deprecated": "This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info",
       "license": "MIT",
       "dependencies": {
         "@langchain/classic": "1.0.27",
@@ -7996,13 +7561,10 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -8115,6 +7677,37 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/@n8n/ai-utilities/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@n8n/ai-utilities/node_modules/undici": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
@@ -8148,10 +7741,28 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@n8n/ai-utilities/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/ai-utilities/node_modules/zod-to-json-schema": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.23.3"
+      }
+    },
     "node_modules/@n8n/ai-workflow-builder": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-1.23.0.tgz",
-      "integrity": "sha512-OwZz7AMStDS1sP5HV01cAJTiDDKl2ogpZNsU4CwqSUDGRbzqD5pWqPgxZ14Fo1IP+Q81P0W9bK4r2wwZ1dp0Rg==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-1.26.1.tgz",
+      "integrity": "sha512-B7DE1SgCwP+U7500FeZDsf/Yy3VjKCjfNnjdZ1qlx4mH8U/+VxZOIQ1FpzC8L1rFKzfLGy8+Fa2ONOlmBii5vg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@langchain/anthropic": "1.3.27",
@@ -8160,19 +7771,20 @@
         "@langchain/openai": "1.4.4",
         "@mozilla/readability": "0.6.0",
         "@n8n_io/ai-assistant-sdk": "1.21.0",
-        "@n8n/ai-utilities": "0.17.0",
-        "@n8n/api-types": "1.23.0",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/utils": "1.32.0",
-        "@n8n/workflow-sdk": "0.16.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/utils": "1.34.0",
+        "@n8n/workflow-sdk": "0.19.1",
+        "axios": "1.16.1",
         "csv-parse": "6.2.1",
         "jsdom": "23.0.1",
         "langchain": "1.2.30",
         "langsmith": "^0.4.6",
         "lodash": "4.18.1",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "picocolors": "1.0.1",
         "turndown": "^7.2.2",
         "zod": "3.25.67"
@@ -8201,9 +7813,9 @@
       }
     },
     "node_modules/@n8n/ai-workflow-builder/node_modules/@langchain/core/node_modules/langsmith": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.2.tgz",
-      "integrity": "sha512-3dZUwQDJluxi2ih5eIygFODtlrQKrs3Tua0Ck3l+DAUkSGFkB1Dc0JPqkGbqiVSN+TQDElnkev/ydAOAz6jndA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.6.tgz",
+      "integrity": "sha512-6IRm+sAxHT2n5GAZbqEnUzkhOu3Q8vqQtMiOpYfGiI+pxUe/fYQSzV0Pr7q5x9JD8bnZ8xK2/P9dhPHs4zO/Nw==",
       "license": "MIT",
       "dependencies": {
         "p-queue": "6.6.2"
@@ -8242,6 +7854,20 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@n8n/ai-workflow-builder/node_modules/@n8n/api-types": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+      "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/permissions": "0.63.0",
+        "n8n-workflow": "2.26.1",
+        "xss": "1.0.15"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
     "node_modules/@n8n/ai-workflow-builder/node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -8258,6 +7884,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@n8n/ai-workflow-builder/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@n8n/ai-workflow-builder/node_modules/langsmith": {
@@ -8308,16 +7950,34 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@n8n/ai-workflow-builder/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+    "node_modules/@n8n/ai-workflow-builder/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
       },
-      "engines": {
-        "node": ">=10"
+      "peerDependencies": {
+        "zod": "3.25.67"
       }
     },
     "node_modules/@n8n/ai-workflow-builder/node_modules/uuid": {
@@ -8333,33 +7993,28 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
-    "node_modules/@n8n/api-types": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.23.0.tgz",
-      "integrity": "sha512-m1jTiZ4WAEeY3lQCLjzFBj7sN1PHYlY9Ax68sg113YQHekzeTrk6l1GQwqxeJVpX+DiyXg6sROvi4klpvI+baA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/permissions": "0.61.0",
-        "n8n-workflow": "2.23.0",
-        "xss": "1.0.15"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
+    "node_modules/@n8n/ai-workflow-builder/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/backend-common": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.23.0.tgz",
-      "integrity": "sha512-1qqvc8AH/SdN3RE3a23l1VIrSH8PtR2LPasI3VcobjQrZz5Ak8GbZhxVbSM+oCdx68YdoCSWFsMzN6N6OWq8pg==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.26.1.tgz",
+      "integrity": "sha512-imE00ovHfy9sYQrxLy/9cCj4wjiLDBKbL4Bit5bGKWT+mnDKIIB22Q+wiZDthIpYfIGCciignYzlvJyEuj8kWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
         "callsites": "3.1.0",
         "flatted": "3.4.2",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "picocolors": "1.0.1",
         "reflect-metadata": "0.2.2",
         "stream-json": "1.9.1",
@@ -8367,123 +8022,787 @@
         "yargs-parser": "21.1.1"
       }
     },
-    "node_modules/@n8n/chat-hub": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/chat-hub/-/chat-hub-1.16.0.tgz",
-      "integrity": "sha512-s11MDWPbWke17tkQS11GxNT18S6NY8h5AY4HzVxImtmRw+I8QyiENRw1d9S1KxdS+r7DhQjAAPgySm6joIHpDQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+    "node_modules/@n8n/backend-common/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
-        "@n8n/api-types": "1.23.0"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "node_modules/@n8n/client-oauth2": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@n8n/client-oauth2/-/client-oauth2-1.7.0.tgz",
-      "integrity": "sha512-YOWL5mh6T5Ak6ohLE67JfyhF5RZZFQlSoMNHAkgpfqSqcyDha/xztz5czXFWOoiXku0yeru1wNwIEx/tqcqD7Q==",
+    "node_modules/@n8n/backend-common/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "axios": "1.16.1"
-      }
-    },
-    "node_modules/@n8n/config": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.22.0.tgz",
-      "integrity": "sha512-vVO8Xj+aY4vqrC6lAvdHt3KqIwDXMTUG79jxZygdB/smUfB9TkxPyi5KGfTuVGo0tdB2wNQKx4lmgc10squHRg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/di": "0.12.0",
-        "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/constants": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.25.0.tgz",
-      "integrity": "sha512-l82Iwp8y/KEzuQeW2IeUhwroKM4Cbt0IkFRBwd2fZvHbEyFySnfB+KGULowFQLWtgbnscJRj1YJIlBw8gRSDuw==",
-      "license": "SEE LICENSE IN LICENSE.md"
-    },
-    "node_modules/@n8n/db": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-1.23.0.tgz",
-      "integrity": "sha512-eULIs9XUDjd1bqzhsKHP51H6dAmmJysIBappnBzEcK655dhjpYB+OSR+AML56iVC2WZJrZMCUrhaH+y2b5bMRg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/api-types": "1.23.0",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/permissions": "0.61.0",
-        "@n8n/typeorm": "0.3.20-17",
-        "@n8n/utils": "1.32.0",
-        "class-validator": "0.14.0",
-        "flatted": "3.4.2",
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
         "lodash": "4.18.1",
-        "n8n-core": "2.23.0",
-        "n8n-workflow": "2.23.0",
-        "nanoid": "3.3.8",
-        "p-lazy": "3.1.0",
-        "reflect-metadata": "0.2.2",
-        "uuid": "10.0.0",
-        "xss": "1.0.15",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
         "zod": "3.25.67"
       }
     },
-    "node_modules/@n8n/db/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+    "node_modules/@n8n/backend-common/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/backend-common/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/chat-hub": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@n8n/chat-hub/-/chat-hub-1.19.1.tgz",
+      "integrity": "sha512-g8DNjan1zu8lJlLVMElzYPaG8tab/ZXuxVe99BpZZhQaQnj13k02B7Up/0Ft/7Jtc5CJhps6KvnlDf2nmTm28Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/api-types": "1.26.1"
+      }
+    },
+    "node_modules/@n8n/chat-hub/node_modules/@n8n/api-types": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+      "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/permissions": "0.63.0",
+        "n8n-workflow": "2.26.1",
+        "xss": "1.0.15"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/chat-hub/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@n8n/chat-hub/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/chat-hub/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/chat-hub/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/client-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@n8n/client-oauth2/-/client-oauth2-1.8.0.tgz",
+      "integrity": "sha512-Ol5Cx1nr1BLUmqp+6TMgfh+/d7sQORcZnuPnOmTtZOsNCTQWy5DQIRBnCjJQouDwbcRmjlyoej4W4a/dHr/K/w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "axios": "1.16.1"
+      }
+    },
+    "node_modules/@n8n/config": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.24.0.tgz",
+      "integrity": "sha512-UNNJQNnyCo6FfdqtP5JbkZ8ztOexuq4JseiznIRR8H45E/pm0aP2HftXJM8IHVpcQeKRv1XpbRZSlFdZd3pwbw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/constants": "0.26.0",
+        "@n8n/di": "0.13.0",
+        "reflect-metadata": "0.2.2",
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/config/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/constants": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.26.0.tgz",
+      "integrity": "sha512-25BYGmGBD6zmbrbwJys0bHzmSiEth374kmzii3HC8jVfx0Lyms+vh1rzjAnvcvcY/zkJ8ic3fDvewvpzasb6AQ==",
+      "license": "SEE LICENSE IN LICENSE.md"
+    },
+    "node_modules/@n8n/db": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-1.26.1.tgz",
+      "integrity": "sha512-/u1qzA+xsR2UAwMGnYDb1XMdeK56OzgwHnDgVAN9UiPJDjPsXhQvMGipoJit48E+bQrB+wUZGNaU3iJZ0+0slg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/api-types": "1.26.1",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/permissions": "0.63.0",
+        "@n8n/typeorm": "0.3.20-17",
+        "@n8n/utils": "1.34.0",
+        "class-validator": "0.14.0",
+        "flatted": "3.4.2",
+        "lodash": "4.18.1",
+        "n8n-core": "2.26.1",
+        "n8n-workflow": "2.26.1",
+        "nanoid": "3.3.8",
+        "p-lazy": "3.1.0",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.1.1",
+        "xss": "1.0.15",
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@aws-sdk/client-s3": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.808.0.tgz",
+      "integrity": "sha512-8RY3Jsm84twmYfiqnMkxznuY6pBX7y2GiuEJVdW1ZJLXRDOiCPkTBHsO6jUwppfMua7HRhO2OTAdWr7aSBAdPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+        "@aws-sdk/middleware-expect-continue": "3.804.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-location-constraint": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-sdk-s3": "3.808.0",
+        "@aws-sdk/middleware-ssec": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/signature-v4-multi-region": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@aws-sdk/xml-builder": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-blob-browser": "^4.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/hash-stream-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/md5-js": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
+      "integrity": "sha512-NW1yoTYDH2h8ycqMPNkvW3d1XT2vEeXfXclagL2tv82P7Qt7vPXYcObs/YtETvNZ7hdnmOftJ/IJv7YrFC8vtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.808.0.tgz",
+      "integrity": "sha512-qvyJTDf0HIsPpZzBUqhNQm5g8stAn2EOwVsaAolsOHuBsdaBAE/s/NgPzazDlSXwdF0ITvsIouUVDCn4fJGJqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.808.0.tgz",
+      "integrity": "sha512-lQuEB6JK81eKV7fdiktmRq06Y1KCcJbx9fLf7b19nSfYUbJSn/kfSpHPv/tOkJK2HKnN61JsfG19YU8k4SOU8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
+      "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@langchain/core": {
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@langchain/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/@n8n/api-types": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+      "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/permissions": "0.63.0",
+        "n8n-workflow": "2.26.1",
+        "xss": "1.0.15"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/n8n-core": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.26.1.tgz",
+      "integrity": "sha512-X0IO6e89aGVA3PUPz0YhE/CwHoipeHaGBVlFs0FHEq+DZq5D21HQkbHT89+OBQLM58Vd5fGE0ceITgeeaSbhPA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.808.0",
+        "@langchain/core": "1.1.41",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/workflow-sdk": "0.19.1",
+        "@sentry/node": "^10.55.0",
+        "@sentry/node-native": "^10.55.0",
+        "@sentry/profiling-node": "^10.55.0",
+        "axios": "1.16.1",
+        "cache-manager": "5.2.3",
+        "callsites": "3.1.0",
+        "chardet": "2.0.0",
+        "cron": "4.4.0",
+        "fast-glob": "3.2.12",
+        "file-type": "16.5.4",
+        "form-data": "4.0.4",
+        "htmlparser2": "^10.0.0",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "iconv-lite": "0.6.3",
+        "jsonwebtoken": "9.0.3",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "mime-types": "3.0.2",
+        "n8n-workflow": "2.26.1",
+        "nanoid": "3.3.8",
+        "oauth-1.0a": "2.2.6",
+        "p-cancelable": "2.1.1",
+        "picocolors": "1.0.1",
+        "pretty-bytes": "5.6.0",
+        "proxy-from-env": "^1.1.0",
+        "qs": "6.14.2",
+        "ssh2": "1.15.0",
+        "uuid": "11.1.1",
+        "winston": "3.14.2",
+        "xml2js": "0.6.2"
+      },
+      "bin": {
+        "n8n-copy-static-files": "bin/copy-static-files",
+        "n8n-generate-metadata": "bin/generate-metadata",
+        "n8n-generate-node-defs": "bin/generate-node-defs",
+        "n8n-generate-translations": "bin/generate-translations"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/n8n-core/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/ssh2": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.9",
+        "nan": "^2.18.0"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/db/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/decorators": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.23.0.tgz",
-      "integrity": "sha512-epGFm2+YXvt7K55tRihknZ6Ot53v096n8dCN6UMHxpDPPo2dwhY9Vd2Lq+a7thDiIa9qmrHScb3IoI7dkVB4IA==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.26.1.tgz",
+      "integrity": "sha512-9n+kBAgk+yX2Yn/cRWoqOYNomehKU4N3nFwgYHQ+J4eEj+hPXlYmgY1XzZB5UxDTkWFZfxzOZA5Mupp4r8QwqA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/api-types": "1.23.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/permissions": "0.61.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/constants": "0.26.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/permissions": "0.63.0",
         "lodash": "4.18.1",
-        "n8n-workflow": "2.23.0"
+        "n8n-workflow": "2.26.1"
+      }
+    },
+    "node_modules/@n8n/decorators/node_modules/@n8n/api-types": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+      "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/permissions": "0.63.0",
+        "n8n-workflow": "2.26.1",
+        "xss": "1.0.15"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/decorators/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@n8n/decorators/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/decorators/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/decorators/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/di": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.12.0.tgz",
-      "integrity": "sha512-qZWcViQhOAIHewhAqaGkQ/ixAiK0Ki3FQ45Xwh+pkPoL587HOKZjlMSETnTssANL7IQvAtu+Cf/ug2XnTkYXTg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.13.0.tgz",
+      "integrity": "sha512-pxsmn2UqcSnMQwb2zSSZcZZMViiOUnJVrRLoDZPhUZVbdAhmttQJGtm82+6hWPEc4wAOAMFbO1U3X53Wu29Y2g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "reflect-metadata": "0.2.2"
       }
     },
     "node_modules/@n8n/errors": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.8.0.tgz",
-      "integrity": "sha512-aAYL79o/bio21zxzXCGwqnvhPcEsK+HqKNz5DsPGY0tMo6FEFT2mowtxcYRoRbHbx9siraJVhiu+VN+Ya7Iv0g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.9.0.tgz",
+      "integrity": "sha512-FDSpOMLD4SKZ3GlZXJXwCvszqd1ze7HaJMmGyubSB+67BKmUfV5k4oSAdbdzXWC4ughObh0JA8epOWKxnj2u1A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "callsites": "3.1.0"
       }
     },
     "node_modules/@n8n/expression-runtime": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.15.0.tgz",
-      "integrity": "sha512-0MlWU8p+QYGS+KVXx+mBx1rKvFfx9DUXGotDgFwwQOlBFa+Q6Ah1sWMH1655eGKn+zC9bhZfHyssndeNEPWJdA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.17.0.tgz",
+      "integrity": "sha512-/TLh83BjBr0cSRsXZhjxQ4xN5Ssmoxn33ydhn2gKjWN8RMtINnAPHT8UsGMB85nK8BV+bCZOQsMxq4auuTving==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/errors": "0.8.0",
-        "@n8n/tournament": "1.2.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/tournament": "1.3.0",
         "isolated-vm": "^6.1.2",
         "jmespath": "0.16.0",
         "js-base64": "3.7.8",
@@ -8496,10 +8815,19 @@
         "zod": "3.25.67"
       }
     },
+    "node_modules/@n8n/expression-runtime/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@n8n/imap": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@n8n/imap/-/imap-0.20.0.tgz",
-      "integrity": "sha512-I53KJ2gfm518AGNpv1y/0k5URkw7cEqoTXYNfOSKlCHlmDrWP8UH6Ta3wVwjBWYHhA79JSLbct4Ifdyjd0knDQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@n8n/imap/-/imap-0.21.0.tgz",
+      "integrity": "sha512-3QSSo9zkBuUk8nV3mbZOJLjXThv7c6hxPGZlTcTJT/QcT9H2yZpEDE+TthEPc2nh2qGk7aWIEgp4tfZQ2EvWOA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "iconv-lite": "0.6.3",
@@ -8521,21 +8849,21 @@
       }
     },
     "node_modules/@n8n/instance-ai": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@n8n/instance-ai/-/instance-ai-1.8.0.tgz",
-      "integrity": "sha512-7sD3kxN58iDFb9cvWj+KKzYF+gU08bSUIK8TFyN6a+rMUOwM6+7UdjHWKVqF8g4ckgg4Bp2SlVUU/nSOUiMmVg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@n8n/instance-ai/-/instance-ai-1.11.1.tgz",
+      "integrity": "sha512-89Ntij3U6rC0x/9vCfwl9H1+WX35GxD4zk1g/SGVP8cI9oG3YJ/8x+vqon4bTcRmRGZM2WVDg+1iZBholSWpGw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@daytonaio/sdk": "0.175.0",
         "@joplin/turndown-plugin-gfm": "^1.0.12",
         "@mozilla/readability": "^0.6.0",
-        "@n8n/agents": "0.9.0",
-        "@n8n/api-types": "1.23.0",
-        "@n8n/mcp-browser": "0.7.0",
-        "@n8n/sandbox-client": "0.0.4",
-        "@n8n/utils": "1.32.0",
-        "@n8n/workflow-sdk": "0.16.0",
+        "@n8n/agents": "0.11.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/mcp-browser": "0.9.1",
+        "@n8n/utils": "1.34.0",
+        "@n8n/workflow-sdk": "0.19.1",
         "@opentelemetry/api": "^1.9.0",
+        "@thednp/dommatrix": "^2.0.12",
         "csv-parse": "6.2.1",
         "fast-glob": "3.2.12",
         "flatted": "3.4.2",
@@ -8543,7 +8871,7 @@
         "linkedom": "^0.18.9",
         "luxon": "3.7.2",
         "mammoth": "1.12.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "p-limit": "^3.1.0",
         "pdf-parse": "2.4.5",
@@ -8554,19 +8882,104 @@
         "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5"
       }
     },
-    "node_modules/@n8n/json-schema-to-zod": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/json-schema-to-zod/-/json-schema-to-zod-1.9.0.tgz",
-      "integrity": "sha512-xOSQHkmz/9xmYXzMb6MRxydpYrAzHdDAfrmLQjtdEyLT51WA/wLbc7LMx04X85qlsfUZfxX4OtEeJFv08mAqow==",
+    "node_modules/@n8n/instance-ai/node_modules/@n8n/api-types": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+      "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/permissions": "0.63.0",
+        "n8n-workflow": "2.26.1",
+        "xss": "1.0.15"
+      },
       "peerDependencies": {
-        "zod": "^3.25.76"
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/instance-ai/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@n8n/instance-ai/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/instance-ai/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/instance-ai/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/mcp-apps": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@n8n/mcp-apps/-/mcp-apps-0.3.0.tgz",
+      "integrity": "sha512-68ZCp2HU0sifOzvIQMbgQzomf3rQ2l9t+E5+kYr1F/RZ6s6N+7y1Mq6w675zVNw7h3j5ZMo1KkWTWq+DIdhPSQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/utils": "1.34.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0"
       }
     },
     "node_modules/@n8n/mcp-browser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@n8n/mcp-browser/-/mcp-browser-0.7.0.tgz",
-      "integrity": "sha512-QusktnXWkIMjKB1Ru/s6UbMdThso1g22DuqWgYlDJkmcFCRSeUTzUwEUyoFacUTl0a3+AYpP17Aw+incgIS/gA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@n8n/mcp-browser/-/mcp-browser-0.9.1.tgz",
+      "integrity": "sha512-D09RsiLVHJ+GCqCu/AHBahto7afjl5SUBr1rJkr7duFud/aXg+tfd54cdzImktfm0geJfgNk4krJGYT/o/7n8g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@joplin/turndown-plugin-gfm": "1.0.64",
@@ -8590,13 +9003,24 @@
       "integrity": "sha512-8GJ7f9OenE3zkSVII5B6qzIkvgF7C/a20gaASEjM6jWPLPJFFQ2nQ3Ou/kXH1mPUTs9dC9VYs8QXVPvZabKXBQ==",
       "license": "MIT"
     },
+    "node_modules/@n8n/mcp-browser/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@n8n/n8n-nodes-langchain": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-2.23.0.tgz",
-      "integrity": "sha512-ANnmr2wptbjOYhvjoononFFh79RIGMtqdzdlNTlRdLeTjZwDOu0FNPGE+VpKW/rJpvSAd5FSHFKAJ27/vtj0vQ==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-2.26.1.tgz",
+      "integrity": "sha512-PVb17ZBOmLaLrW60rlvqRvJzNKxVrk6DSllj3fpab9DklpVegOwvkkyc5hGOI23e8Eqw0Q0X6bFLZJVYNAL3lg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "3.938.0",
         "@aws-sdk/client-sso-oidc": "3.808.0",
+        "@aws-sdk/credential-providers": "3.808.0",
         "@azure/identity": "4.13.0",
         "@azure/search-documents": "12.1.0",
         "@getzep/zep-cloud": "1.0.6",
@@ -8632,17 +9056,18 @@
         "@microsoft/agents-hosting": "1.2.3",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@mozilla/readability": "0.6.0",
-        "@n8n/ai-utilities": "0.17.0",
-        "@n8n/client-oauth2": "1.7.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@n8n/json-schema-to-zod": "1.9.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/json-schema-to-zod": "1.10.0",
         "@n8n/typeorm": "0.3.20-16",
-        "@n8n/typescript-config": "1.4.0",
+        "@n8n/typescript-config": "1.5.0",
         "@oracle/langchain-oracledb": "0.2.0",
         "@pinecone-database/pinecone": "^5.0.2",
         "@qdrant/js-client-rest": "^1.16.2",
+        "@smithy/node-http-handler": "4.5.0",
         "@supabase/supabase-js": "2.50.0",
         "@xata.io/client": "0.28.4",
         "@zilliz/milvus2-sdk-node": "^2.5.7",
@@ -8664,8 +9089,8 @@
         "mime-types": "3.0.2",
         "mongodb": "^6.17.0",
         "mysql2": "3.17.0",
-        "n8n-nodes-base": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-nodes-base": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "openai": "^6.34.0",
         "pg": "8.17.0",
         "redis": "4.6.14",
@@ -8779,6 +9204,7 @@
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.27.tgz",
       "integrity": "sha512-s2U3w7QV7QpkFtY1eZMni4poz+nKLFclpDi3a7hUbZ67ttsGaU9WkZ2BiLuzLIs+IFaUvON/KcGkE8EqAl9aPA==",
+      "deprecated": "This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info",
       "license": "MIT",
       "dependencies": {
         "@langchain/classic": "1.0.27",
@@ -9352,6 +9778,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/@n8n/json-schema-to-zod": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@n8n/json-schema-to-zod/-/json-schema-to-zod-1.10.0.tgz",
+      "integrity": "sha512-GrigkK/oq/cuq/lFa5WxmB34ZGD5aIf6mGVXliePbkXoMU/UaieMmfxOwi+aZ22Gb+J/ANhkgUDFz+olaXXRww==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "zod": "^3.25.76"
+      }
+    },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/@n8n/typeorm": {
       "version": "0.3.20-16",
       "resolved": "https://registry.npmjs.org/@n8n/typeorm/-/typeorm-0.3.20-16.tgz",
@@ -9405,6 +9840,22 @@
         "sqlite3": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/@smithy/node-http-handler": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/ansi-styles": {
@@ -9571,25 +10022,47 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@n8n/n8n-nodes-langchain/node_modules/openai": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-      "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
       },
       "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/n8n-workflow/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/path-scurry": {
@@ -9633,13 +10106,40 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/zod-to-json-schema": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.23.3"
+      }
+    },
     "node_modules/@n8n/permissions": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.61.0.tgz",
-      "integrity": "sha512-5Dcpew/D7l+EKZX8GVzWlTHQzOdUFEO0K6Z+puQiYVhhK2AUYkwrChrefV7dcAAcCZUvTnIdbtbd0Sg27rl4eQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.63.0.tgz",
+      "integrity": "sha512-KsGqEeElwOWsudYBgrpTRDcu6b9LLRaAnMfiJIstURy7OVdbSSSjJ2I3bAEfg+p/jrFsbJAS4JrKHorEIqyi0g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/permissions/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/sandbox-client": {
@@ -9655,38 +10155,467 @@
       }
     },
     "node_modules/@n8n/syslog-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@n8n/syslog-client/-/syslog-client-1.4.0.tgz",
-      "integrity": "sha512-1WYlK9M9qsfkfjpcwmJ8/afjgvpAiKfXH8eCbs8D86xLXSEe72cscOhTe9eNfwbrqcc9EYrz6YrRNpQIZhLUmQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@n8n/syslog-client/-/syslog-client-1.5.0.tgz",
+      "integrity": "sha512-e3W8QwlUU0P7sb9/LUIjmdjm1/PrQV3HjG46T6YD30PmNAxRuj/WZ3nKxVCFLDC3TKDtHioEnmmtmpZK4OHvQw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "zod": "3.25.67"
       }
     },
+    "node_modules/@n8n/syslog-client/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@n8n/task-runner": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-2.23.0.tgz",
-      "integrity": "sha512-b5P2/u3pPCv3DjG5USTXc5RDmAXZh6BMToe3J7rOopxiyfeup/2xhGGw61InJoXH+78T/rstuxpkZnWF7m6vMQ==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-2.26.1.tgz",
+      "integrity": "sha512-TMwxAKePf5e4FhvLjhiasyDQEhb9PsfcOu4smKdP6RO2OXtMGmgy06fDqv5eQvik4sxRocccCiHyEJcuNXeFmA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@sentry/node": "^10.36.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@sentry/node": "^10.55.0",
         "acorn": "8.14.0",
         "acorn-walk": "8.3.4",
         "lodash": "4.18.1",
         "luxon": "3.7.2",
-        "n8n-core": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-core": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "ws": "^8.18.0"
       }
     },
+    "node_modules/@n8n/task-runner/node_modules/@aws-sdk/client-s3": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.808.0.tgz",
+      "integrity": "sha512-8RY3Jsm84twmYfiqnMkxznuY6pBX7y2GiuEJVdW1ZJLXRDOiCPkTBHsO6jUwppfMua7HRhO2OTAdWr7aSBAdPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+        "@aws-sdk/middleware-expect-continue": "3.804.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-location-constraint": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-sdk-s3": "3.808.0",
+        "@aws-sdk/middleware-ssec": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/signature-v4-multi-region": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@aws-sdk/xml-builder": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-blob-browser": "^4.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/hash-stream-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/md5-js": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
+      "integrity": "sha512-NW1yoTYDH2h8ycqMPNkvW3d1XT2vEeXfXclagL2tv82P7Qt7vPXYcObs/YtETvNZ7hdnmOftJ/IJv7YrFC8vtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.808.0.tgz",
+      "integrity": "sha512-qvyJTDf0HIsPpZzBUqhNQm5g8stAn2EOwVsaAolsOHuBsdaBAE/s/NgPzazDlSXwdF0ITvsIouUVDCn4fJGJqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.808.0.tgz",
+      "integrity": "sha512-lQuEB6JK81eKV7fdiktmRq06Y1KCcJbx9fLf7b19nSfYUbJSn/kfSpHPv/tOkJK2HKnN61JsfG19YU8k4SOU8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
+      "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/@langchain/core": {
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/@langchain/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/n8n-core": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.26.1.tgz",
+      "integrity": "sha512-X0IO6e89aGVA3PUPz0YhE/CwHoipeHaGBVlFs0FHEq+DZq5D21HQkbHT89+OBQLM58Vd5fGE0ceITgeeaSbhPA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.808.0",
+        "@langchain/core": "1.1.41",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/workflow-sdk": "0.19.1",
+        "@sentry/node": "^10.55.0",
+        "@sentry/node-native": "^10.55.0",
+        "@sentry/profiling-node": "^10.55.0",
+        "axios": "1.16.1",
+        "cache-manager": "5.2.3",
+        "callsites": "3.1.0",
+        "chardet": "2.0.0",
+        "cron": "4.4.0",
+        "fast-glob": "3.2.12",
+        "file-type": "16.5.4",
+        "form-data": "4.0.4",
+        "htmlparser2": "^10.0.0",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "iconv-lite": "0.6.3",
+        "jsonwebtoken": "9.0.3",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "mime-types": "3.0.2",
+        "n8n-workflow": "2.26.1",
+        "nanoid": "3.3.8",
+        "oauth-1.0a": "2.2.6",
+        "p-cancelable": "2.1.1",
+        "picocolors": "1.0.1",
+        "pretty-bytes": "5.6.0",
+        "proxy-from-env": "^1.1.0",
+        "qs": "6.14.2",
+        "ssh2": "1.15.0",
+        "uuid": "11.1.1",
+        "winston": "3.14.2",
+        "xml2js": "0.6.2"
+      },
+      "bin": {
+        "n8n-copy-static-files": "bin/copy-static-files",
+        "n8n-generate-metadata": "bin/generate-metadata",
+        "n8n-generate-node-defs": "bin/generate-node-defs",
+        "n8n-generate-translations": "bin/generate-translations"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/n8n-core/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/ssh2": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.9",
+        "nan": "^2.18.0"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/task-runner/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@n8n/tournament": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.2.0.tgz",
-      "integrity": "sha512-EY/vqijjYi2LhnKeShNXNtVBJW7lSRGFe5D2ikv5AfDZiLOqneRnNdfwZbv1bTLByRYyzY708KiXF8P66Gr1dg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.3.0.tgz",
+      "integrity": "sha512-tSn3uFKdvXReNdG+VbwNEieSSIEd1V3DGhaD5XD3wIgp3RVX77XGA08h02ov5TYNg6AsQT1LUdicX7LDnlKtvg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -9844,46 +10773,100 @@
       }
     },
     "node_modules/@n8n/typescript-config": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.4.0.tgz",
-      "integrity": "sha512-HC2rgU/FtbOb6vpC/VvqfOxqeMkmQH/YdZK1y/wel7YgMCJcv92IhjJPehW1Qpp+OUesGTn03VJb4vee/ZEBkw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.5.0.tgz",
+      "integrity": "sha512-lRqZYmU0tRPAlVmUDfHBlgceE3GbQ5Zqkomrxs2wq5Kif8QqokJvB2T2xzYRrP3WGMDQbZqXeKs2E8Dm5t+nIw==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/utils": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.32.0.tgz",
-      "integrity": "sha512-cXRVSjrhmWsjLO1dsDirFHrIdZo2cVXkDP2hwFpVkqjdoaRqsJ+6rqUmatKG4nNhtp7uhyRw4tMfKj/qc9s/ww==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.34.0.tgz",
+      "integrity": "sha512-JOaQXZLIBBYN0rmXDd8VXK3OwXPMw1PdCXGSy+5xf6arPzm9+gkGRbrPcgh3vv4/sLbtfqyM7O5ohQK/axjMzQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/constants": "0.25.0",
+        "@n8n/constants": "0.26.0",
         "nanoid": "3.3.8"
       }
     },
     "node_modules/@n8n/workflow-sdk": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/workflow-sdk/-/workflow-sdk-0.16.0.tgz",
-      "integrity": "sha512-DoDr7RByG08AfAOepG56ycVd7IACfBxpCrlHRFLBs2LpQ92TOxwy6fLZcqA1gZAxDkz+/FP0Te4HL/EVSfwplQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@n8n/workflow-sdk/-/workflow-sdk-0.19.1.tgz",
+      "integrity": "sha512-vzmczmW9ZJ5265MssVkqUDLkTu3TFcUSPD/sU1uy06bNYQrguI1t01q+l/mIJKAFfV3Pnb6Sb/IRlUUEkasf6w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "acorn": "8.14.0",
-        "n8n-workflow": "2.23.0",
-        "uuid": "10.0.0",
+        "n8n-workflow": "2.26.1",
+        "uuid": "11.1.1",
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/@n8n/workflow-sdk/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@n8n/workflow-sdk/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
         "zod": "3.25.67"
       }
     },
     "node_modules/@n8n/workflow-sdk/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@n8n/workflow-sdk/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -10083,9 +11066,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -11617,19 +12600,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry-internal/server-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.57.0.tgz",
+      "integrity": "sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/core": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.54.0.tgz",
-      "integrity": "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.54.0.tgz",
-      "integrity": "sha512-Jc31dMBs9aBUv6TXmIPNwv2u18YbfvWQG32IkM3dFWAAoJQhCqLZfN0MEDSf9TeNexIf8qBMZtJRHgHIrWYiGg==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.57.0.tgz",
+      "integrity": "sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
@@ -11637,9 +12632,10 @@
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.54.0",
-        "@sentry/node-core": "10.54.0",
-        "@sentry/opentelemetry": "10.54.0",
+        "@sentry-internal/server-utils": "10.57.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/node-core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -11647,13 +12643,13 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.54.0.tgz",
-      "integrity": "sha512-QR5RnIK78g0Np2+VWMZ3TatM7C+oX9zIQ1W36o3KOjw0nNcXkWjZT1lEu4me8cp2s8s3hA4qT7fwcciQqkj1UQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.57.0.tgz",
+      "integrity": "sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.54.0",
-        "@sentry/opentelemetry": "10.54.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -11689,14 +12685,14 @@
       }
     },
     "node_modules/@sentry/node-native": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-native/-/node-native-10.54.0.tgz",
-      "integrity": "sha512-GmMJFI5swhFRxI1g1MGn2jSx8DzPsYSNV53nTcroS/BviMKRi9CphGgGN0BF2GCenZoNSCaJwVzMt26m9uP/5g==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-native/-/node-native-10.57.0.tgz",
+      "integrity": "sha512-A9r4K63P917mYfIVzc2WRM9LFeht+7r3nCBnwXSCducfJigzYH4EypebydXYnHyDNv0Rb9a5A0viQV0DRxeREQ==",
       "license": "MIT",
       "dependencies": {
         "@sentry-internal/node-native-stacktrace": "^0.5.0",
-        "@sentry/core": "10.54.0",
-        "@sentry/node": "10.54.0"
+        "@sentry/core": "10.57.0",
+        "@sentry/node": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -11732,12 +12728,12 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.54.0.tgz",
-      "integrity": "sha512-58Jk9yMos5DwhamDsNmnoQMSNx0yD9E+h1pZwkw34ve2qB9tv+cys3Oz6nfazT9ZdIsXIgpQntN8AfMXAvv4/g==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.57.0.tgz",
+      "integrity": "sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.54.0"
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -11750,20 +12746,44 @@
       }
     },
     "node_modules/@sentry/profiling-node": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.54.0.tgz",
-      "integrity": "sha512-ZyIG+G2fkG43qijOcD5H93F/gnyrAv86jS1wevbOMjIMQxReeQDhZRWPd08rllIAeaYH4v+DjTZrKAX8aR8cyQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.57.0.tgz",
+      "integrity": "sha512-0E6eWOCVOuXTFCrHxyPA0zgjypmeCJAbtgnvLFF+kmdkzeBb02KmXaJ8lre9SSjHmWAeI2jA6URJiKGOxgE0YQ==",
       "license": "MIT",
       "dependencies": {
         "@sentry-internal/node-cpu-profiler": "^2.4.0",
-        "@sentry/core": "10.54.0",
-        "@sentry/node": "10.54.0"
+        "@sentry/core": "10.57.0",
+        "@sentry/node": "10.57.0"
       },
       "bin": {
         "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@shanghaikid/parquetjs": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@shanghaikid/parquetjs/-/parquetjs-1.8.8.tgz",
+      "integrity": "sha512-uaYXx4yP4cipVU8EZR4OZohiklsazyAcIXtfNEEYBcsMlnz5w4gEvv9vw+cP3yZBv7d1+OQYKfCfKI7oK0iUZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.864.0",
+        "@types/node-int64": "^0.4.32",
+        "@types/thrift": "^0.10.17",
+        "@zenfs/core": "^2.3.8",
+        "brotli-wasm": "^3.0.1",
+        "bson": "6.10.4",
+        "int53": "^1.0.0",
+        "long": "^5.3.2",
+        "node-int64": "^0.4.0",
+        "snappyjs": "^0.7.0",
+        "thrift": "0.23.0",
+        "varint": "^6.0.0",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.18.2"
       }
     },
     "node_modules/@simple-git/args-pathspec": {
@@ -11858,6 +12878,19 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.16.tgz",
+      "integrity": "sha512-YH0c/t1n8dhzz/NyIEoqoHyn4tBvrtESNRUV+ar6to4eqA3jN2OGqhe9hAicmVCokd+EC3puYXsMAG6PDZVEgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
@@ -11889,13 +12922,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11903,13 +12936,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
-      "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11917,12 +12950,12 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.3.4.tgz",
-      "integrity": "sha512-uI00gSvwvBEiVuqpHFcMPGXnVh1XQYuqlQREIX/GUmuwNNTdGRliUI8R71tbfwNLYP7t8E/HVqdohvjoWU13iA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.3.6.tgz",
+      "integrity": "sha512-Ussyv240JxwQP8AmkYdm26wGP/1I8QmIv0ZosgDJDlSzD73FEdj1BOpXMc06VrxX5KxTKhadFNomT2SWutUnpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11930,12 +12963,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.4.tgz",
-      "integrity": "sha512-9szC3PfHhYSvWA98CIrD6rB8jS60tfKOPvDlzyD87gsDm8KDnsSpXnwPO1J3bPxg0tWE6Ljzk2YzZV2GBe3nUQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.6.tgz",
+      "integrity": "sha512-BQao/dBhLCJqo953N1hadkcF3M/9G+i6qIgnMupfdpBQomwyhfV7Xfc5jjpCkm8HxfzaWAGrM/2nNnzronFqVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11943,12 +12976,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.4.tgz",
-      "integrity": "sha512-Q28S5qVeHIGXY4xCO43IFglVCc11HXZlxdhUhcNgiI/ArVDi6SWOMLvWEq1woUQtThNxH3CPbz6l1Z2PT6gl8A==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.6.tgz",
+      "integrity": "sha512-OUoNRXJGZMM4ivoU7QIzOvCLbavD1YnadNEairrtYhTi+gmGhyn3c2wToL9CxEs4Cw2Ab/KeQM39T1K+/e9YdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11956,12 +12989,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.4.tgz",
-      "integrity": "sha512-QxrsfEjVwpx2rzu0ZRc+F1MFSVh9pnjJayHzxjy3l3ru2zp7yt9FsYnDBHmdZV7389wqc1poK84vf5v3lArSaw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.6.tgz",
+      "integrity": "sha512-M6FeKRMi3oecpTy4EL5n1hLPWydw+xInFYQIzjbGYGBnFtW7IlJjnXrKr/Ev1GpMtmw44QCmrl8+ACEFPmRsIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11969,13 +13002,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
-      "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11983,12 +13016,12 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.4.tgz",
-      "integrity": "sha512-HQw/cCLjoAatHffbVQxanPfDRYFt3NMhAENub1/Pw0iftGYGSS4+4C+G1D7CCJXW5/wR6AIhLT7xPusMqy7qjg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.6.tgz",
+      "integrity": "sha512-/8D8rOFs2VEwvHwsx68sb6nE7XfVr2wbJTbC1YuKBHPhHeMnOt7IHxr7CoT5wBWujdV4fjVoLPn1BXXP4Ijlow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12011,12 +13044,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.4.tgz",
-      "integrity": "sha512-wuwVYqGNP9RwLs5hU2nTg8ajL16lA27VX7oGrsarghiqOhAtGYWQQ2VNtotKCBra5t4Od+Epi5jYktm0JwDuIQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.6.tgz",
+      "integrity": "sha512-Ziap41FoxpKqmlO9IE68NeFwPKhUJD4PVNcCQ2tl6IUCPSj0KykIuAPnJNWIQbWXvApwCauhRNlAFdt9KRvDpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12049,12 +13082,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.4.tgz",
-      "integrity": "sha512-drsFcLEIjFtmDF8Ta5STY7zTc89L24qL+G2f+YGo2oeoB3OW/6zjhKwW8/nCTS45AAFSyh81UgJ+Jl+Gs0ovnQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.6.tgz",
+      "integrity": "sha512-LYcuBrO9oiajdRFHyFx3FJAWNKrP89s0grI6mcfpwTAeX2ZJ/9Xyi7Imghh9LT6CIcAy6/k6/MpoUiPNjXr1/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12185,13 +13218,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
-      "integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12218,6 +13251,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.3.6.tgz",
+      "integrity": "sha512-BicTiH0vBGknILtW9mIO+fdO1UY5khbqOMehbGDv6iecYruVSRuEyOazsThj9OSQHw0LfDGQaxj6s6rwWhvggw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12263,13 +13309,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
-      "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12295,9 +13341,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -12514,12 +13560,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.4.tgz",
-      "integrity": "sha512-Qt+W1pLeV/gmsXXUKbcolZqSGwnEdcxM7tqZjtGazkJ4feMUX0Vy+mCZGyhCwLvO8qxsrhYlmRZ7FLGUxJ4Scg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.6.tgz",
+      "integrity": "sha512-oTt3OP9NcJkrySCSCCdSbP6XLSMNgOmt/ulaiYtb0Ng6tfEWtXQ1mwfyqmLd+GapmDUjbU2mgkf7QIq9H4ij/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12696,15 +13742,6 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@types/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -13106,16 +14143,18 @@
       "optional": true
     },
     "node_modules/@zenfs/core": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-1.11.4.tgz",
-      "integrity": "sha512-jFihhedKitw1X9rlImtaca4KTs1Xk9awo4GxUemqt2ucE1jLi10lyRfFFbiYXZsFDkuCWGHwEQwv7BeDIEXMbQ==",
-      "license": "MIT",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-2.5.6.tgz",
+      "integrity": "sha512-1BLPS6fsBN2keGDErbz548Cu6fT0xbVQlrVYNK5OAr9aviR2mC/F/4wxdb+dQZ4P4pVxxHI2DVouyniZ8yHxTw==",
+      "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@types/node": "^22.10.1",
+        "@types/node": "^25.2.0",
         "buffer": "^6.0.3",
         "eventemitter3": "^5.0.1",
+        "kerium": "^1.3.4",
+        "memium": "^0.4.0",
         "readable-stream": "^4.5.2",
-        "utilium": "^1.3.3"
+        "utilium": "^3.0.0"
       },
       "bin": {
         "make-index": "scripts/make-index.js",
@@ -13131,12 +14170,12 @@
       }
     },
     "node_modules/@zenfs/core/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@zenfs/core/node_modules/buffer": {
@@ -13186,26 +14225,26 @@
       }
     },
     "node_modules/@zenfs/core/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@zilliz/milvus2-sdk-node": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/@zilliz/milvus2-sdk-node/-/milvus2-sdk-node-2.6.14.tgz",
-      "integrity": "sha512-S/DEVvzVnFmxoRCnWA9MBaMgSa1t3LEVKex+1+iJEZFPmrpk0OA9tUVfTgbNvzvV/JlWLH68h7vOAPWz/CsXzQ==",
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/@zilliz/milvus2-sdk-node/-/milvus2-sdk-node-2.6.17.tgz",
+      "integrity": "sha512-Z+fCxhuHLV4kogU1T5SS9hDJqLH3KBEceU5snqDV/WDl6uxgNomqZY9md8TTRkHBISqNzDawEaZsi4MF6Y0oWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dsnp/parquetjs": "^1.8.7",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@petamoriken/float16": "^3.8.6",
+        "@shanghaikid/parquetjs": "1.8.8",
         "dayjs": "^1.11.7",
         "generic-pool": "^3.9.0",
         "lru-cache": "^9.1.2",
-        "protobufjs": "^7.2.6",
+        "protobufjs": "^7.5.8",
         "winston": "^3.9.0"
       }
     },
@@ -13393,12 +14432,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.191",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.191.tgz",
-      "integrity": "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==",
+      "version": "6.0.199",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.199.tgz",
+      "integrity": "sha512-6H9RPEjzBQECM+eU1JxAh6jHcZPU/6q5QZ8D8QV8agubf0Mm/kcBlwqrFcFtup6RQzmEvMkVaQOoLCZ8bQ13lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.120",
+        "@ai-sdk/gateway": "3.0.127",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@opentelemetry/api": "^1.9.0"
@@ -13408,18 +14447,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/ajv": {
@@ -13539,6 +14566,18 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/app-root-path": {
@@ -14201,9 +15240,9 @@
       ]
     },
     "node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
@@ -14846,18 +15885,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/chromadb/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -15207,9 +16234,9 @@
       "optional": true
     },
     "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.16.1.tgz",
+      "integrity": "sha512-Sc9FRJ4O9xKGNrvulNdPfK5SyBcZ6lcaRnDE4AQ/uw6IDtjHhsqyzzqcnMikjyGaiOOF2tNOKoBhbVjRvFy9Lw==",
       "license": "MIT",
       "dependencies": {
         "simple-wcswidth": "^1.1.2"
@@ -16317,9 +17344,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -16386,6 +17413,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint-config-riot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
+      "integrity": "sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -17709,9 +18743,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -18112,9 +19146,9 @@
       "license": "MIT"
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
+      "integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -18164,29 +19198,6 @@
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/infisical-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/infisical-node/-/infisical-node-1.3.0.tgz",
-      "integrity": "sha512-tTnnExRAO/ZyqiRdnSlBisErNToYWgtunMWh+8opClEt5qjX7l6HC/b4oGo2AuR2Pf41IR+oqo+dzkM1TCvlUA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "axios": "^1.3.3",
-        "dotenv": "^16.0.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
-    "node_modules/infisical-node/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -19287,6 +20298,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/kerium": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/kerium/-/kerium-1.3.9.tgz",
+      "integrity": "sha512-uoiTcutvUOjOpck8mmUUq7EsuNPhdfFoYMVehLmJGfdLmWC3nABU8KB63MQM0ydkAM4q+2zZmRIKovbx2LF8iA==",
+      "license": "MIT",
+      "dependencies": {
+        "utilium": "^3.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/james-pre"
+      }
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -19313,22 +20337,22 @@
       }
     },
     "node_modules/langchain/node_modules/@langchain/langgraph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.7.tgz",
+      "integrity": "sha512-6WNskiu3bpy3XFwiD9cm4n2QapnFVX7dqYeJzuEAUGp9R3vbxngRVyb5+Myp5Rz4GCFXGXuhcFSjLVRHPhsNtQ==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.2",
-        "@langchain/langgraph-sdk": "~1.9.4",
-        "@langchain/protocol": "^0.0.15",
+        "@langchain/langgraph-checkpoint": "^1.0.4",
+        "@langchain/langgraph-sdk": "~1.9.19",
+        "@langchain/protocol": "^0.0.16",
         "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -19339,19 +20363,19 @@
       }
     },
     "node_modules/langchain/node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.8.tgz",
-      "integrity": "sha512-t7HcTy5QL0taI4Zm096yWK5m99n0uW898E7fE8ub4h2+0Ylype5I9Ph3oAB2kCRzTtT/fVwDhsj90t8/c+aNAw==",
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.20.tgz",
+      "integrity": "sha512-waZQNUN6apVg3jvDApy16wUGwrCvJB8WXHbIPvVrrUZHObqx0w5tk7P/Ite5Qvu4abWrvNtrmqk2zmcqCx7jVw==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/protocol": "^0.0.15",
+        "@langchain/protocol": "^0.0.16",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
         "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.44",
+        "@langchain/core": "^1.1.48",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
@@ -19373,9 +20397,9 @@
       }
     },
     "node_modules/langchain/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -19386,17 +20410,16 @@
       }
     },
     "node_modules/langchain/node_modules/@langchain/langgraph/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/langchain/node_modules/eventemitter3": {
@@ -19461,15 +20484,6 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
-    "node_modules/langchain/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/langsmith": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.6.0.tgz",
@@ -19504,38 +20518,15 @@
       }
     },
     "node_modules/ldapts": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-4.2.6.tgz",
-      "integrity": "sha512-r1eOj2PtTJi+9aZxLirktoHntuYXlbQD9ZXCjiZmJx0VBQtBcWc+rueqABuh/AxMcFHNPDSJLJAXxoj5VevTwQ==",
+      "version": "8.1.7",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.7.tgz",
+      "integrity": "sha512-TJl6T92eIwMf/OJ0hDfKVa6ISwzo+lqCWCI5Mf//ARlKa3LKQZaSrme/H2rCRBhW0DZCQlrsV+fgoW5YHRNLUw==",
       "license": "MIT",
       "dependencies": {
-        "@types/asn1": ">=0.2.0",
-        "@types/node": ">=14",
-        "@types/uuid": ">=9",
-        "asn1": "~0.2.6",
-        "debug": "~4.3.4",
-        "strict-event-emitter-types": "~2.0.0",
-        "uuid": "~9.0.0"
+        "strict-event-emitter-types": "2.0.0"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/ldapts/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=20"
       }
     },
     "node_modules/leac": {
@@ -19578,9 +20569,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.3.tgz",
-      "integrity": "sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
       "license": "MIT"
     },
     "node_modules/libqp": {
@@ -20324,6 +21315,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/memium": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/memium/-/memium-0.4.5.tgz",
+      "integrity": "sha512-mnmHWWlcyKnkKSSU0qL1Jsg+CsoikVZ2xsOatAN89R+j4V3m3WlQr0nUoqcjKDyUVF5ZGdNinRiZGVd+7A+TJQ==",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "kerium": "^1.3.2",
+        "utilium": "^3.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/james-pre"
       }
     },
     "node_modules/memory-pager": {
@@ -21327,15 +22332,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/mongodb/node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
     "node_modules/mqtt": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.7.2.tgz",
@@ -21600,48 +22596,49 @@
       }
     },
     "node_modules/n8n": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n/-/n8n-2.23.0.tgz",
-      "integrity": "sha512-XY2PHnQ9cTSNRBlzIXFJ/peiWylytK/rlnfoSXomu8AGqRNHK4YgTbsJ61xj6Gk5hCLO5wSyUXH5hxORzNna3A==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/n8n/-/n8n-2.26.2.tgz",
+      "integrity": "sha512-1o6zrLCHMtOgCBevbfz7Q15FHAWKPu0wLz7yNBms2jP+qe6aQrojVYwwo+3nzu4Dor4zbd1ek9VwhVxD5bp0Hg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@1password/connect": "1.4.2",
-        "@ai-sdk/anthropic": "3.0.58",
+        "@ai-sdk/anthropic": "^3.0.81",
         "@apidevtools/json-schema-ref-parser": "12.0.2",
         "@aws-sdk/client-secrets-manager": "3.808.0",
         "@azure/identity": "4.13.0",
         "@azure/keyvault-secrets": "4.8.0",
-        "@chat-adapter/linear": "^4.26.0",
-        "@chat-adapter/slack": "^4.26.0",
-        "@chat-adapter/state-memory": "^4.26.0",
-        "@chat-adapter/telegram": "^4.26.0",
+        "@chat-adapter/linear": "^4.28.1",
+        "@chat-adapter/slack": "^4.28.1",
+        "@chat-adapter/state-memory": "^4.28.1",
+        "@chat-adapter/telegram": "^4.28.1",
         "@google-cloud/secret-manager": "5.6.0",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@n8n_io/ai-assistant-sdk": "1.21.0",
         "@n8n_io/license-sdk": "2.25.0",
-        "@n8n/agents": "0.9.0",
-        "@n8n/ai-node-sdk": "0.14.0",
-        "@n8n/ai-utilities": "0.17.0",
-        "@n8n/ai-workflow-builder": "1.23.0",
-        "@n8n/api-types": "1.23.0",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/chat-hub": "1.16.0",
-        "@n8n/client-oauth2": "1.7.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/db": "1.23.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@n8n/expression-runtime": "0.15.0",
-        "@n8n/instance-ai": "1.8.0",
-        "@n8n/n8n-nodes-langchain": "2.23.0",
-        "@n8n/permissions": "0.61.0",
-        "@n8n/syslog-client": "1.4.0",
-        "@n8n/task-runner": "2.23.0",
+        "@n8n/agents": "0.11.0",
+        "@n8n/ai-node-sdk": "0.16.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/ai-workflow-builder": "1.26.1",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/chat-hub": "1.19.1",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/db": "1.26.1",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/instance-ai": "1.11.1",
+        "@n8n/mcp-apps": "0.3.0",
+        "@n8n/n8n-nodes-langchain": "2.26.1",
+        "@n8n/permissions": "0.63.0",
+        "@n8n/syslog-client": "1.5.0",
+        "@n8n/task-runner": "2.26.1",
         "@n8n/typeorm": "0.3.20-17",
-        "@n8n/utils": "1.32.0",
-        "@n8n/workflow-sdk": "0.16.0",
+        "@n8n/utils": "1.34.0",
+        "@n8n/workflow-sdk": "0.19.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.217.0",
         "@opentelemetry/instrumentation": "^0.217.0",
@@ -21652,14 +22649,14 @@
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@parcel/watcher": "^2.5.1",
         "@rudderstack/rudder-sdk-node": "3.0.5",
-        "@sentry/node": "^10.36.0",
+        "@sentry/node": "^10.55.0",
         "aws4": "1.11.0",
         "axios": "1.16.1",
         "bcryptjs": "2.4.3",
         "bull": "4.16.4",
         "cache-manager": "5.2.3",
         "change-case": "4.1.2",
-        "chat": "^4.26.0",
+        "chat": "^4.28.1",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.0",
         "compression": "1.8.1",
@@ -21676,13 +22673,13 @@
         "express-rate-limit": "7.5.0",
         "fast-glob": "3.2.12",
         "fast-json-patch": "^3.1.1",
+        "fastest-levenshtein": "1.0.16",
         "flat": "5.0.2",
         "flatted": "3.4.2",
         "formidable": "3.5.4",
         "handlebars": "4.7.9",
         "helmet": "8.1.0",
         "http-proxy-middleware": "^3.0.5",
-        "infisical-node": "1.3.0",
         "ioredis": "5.3.2",
         "isbot": "3.6.13",
         "isolated-vm": "^6.1.2",
@@ -21691,22 +22688,23 @@
         "jsonschema": "1.4.1",
         "jsonwebtoken": "9.0.3",
         "langsmith": "0.6.0",
-        "ldapts": "4.2.6",
+        "ldapts": "8.1.7",
         "lodash": "4.18.1",
         "luxon": "3.7.2",
-        "n8n-core": "2.23.0",
-        "n8n-editor-ui": "2.23.0",
-        "n8n-nodes-base": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-core": "2.26.1",
+        "n8n-editor-ui": "2.26.1",
+        "n8n-nodes-base": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "nodemailer": "7.0.11",
         "oauth-1.0a": "2.2.6",
         "open": "7.4.2",
-        "openid-client": "6.5.0",
+        "openid-client": "6.8.4",
         "otpauth": "9.1.1",
         "p-cancelable": "2.1.1",
         "p-lazy": "3.1.0",
         "p-limit": "^3.1.0",
+        "pdf-parse": "2.4.5",
         "pg": "8.17.0",
         "picocolors": "1.0.1",
         "pkce-challenge": "5.0.0",
@@ -21718,7 +22716,7 @@
         "reflect-metadata": "0.2.2",
         "replacestream": "4.0.3",
         "samlify": "2.13.0",
-        "semver": "7.5.4",
+        "semver": "7.7.3",
         "shelljs": "0.8.5",
         "simple-git": "3.36.0",
         "source-map-support": "0.5.21",
@@ -21728,7 +22726,7 @@
         "swagger-ui-express": "5.0.1",
         "tar": "^7.5.11",
         "undici": "^7.16.0",
-        "uuid": "10.0.0",
+        "uuid": "11.1.1",
         "validator": "13.15.22",
         "ws": "8.20.1",
         "xml2js": "0.6.2",
@@ -21746,474 +22744,25 @@
         "node": ">=22.22"
       }
     },
-    "node_modules/n8n-core": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.23.0.tgz",
-      "integrity": "sha512-GHadiHhekYWLDeLA7UfqS4XCjdtX2unxZUzOHyQCEWyDUPmygA4SSucxXmNFbCQTAG3MywdlgMB/mdMw+4x6kw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-s3": "3.808.0",
-        "@langchain/core": "1.1.41",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/client-oauth2": "1.7.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/workflow-sdk": "0.16.0",
-        "@sentry/node": "^10.36.0",
-        "@sentry/node-native": "^10.36.0",
-        "@sentry/profiling-node": "^10.36.0",
-        "axios": "1.16.1",
-        "callsites": "3.1.0",
-        "chardet": "2.0.0",
-        "cron": "4.4.0",
-        "fast-glob": "3.2.12",
-        "file-type": "16.5.4",
-        "form-data": "4.0.4",
-        "htmlparser2": "^10.0.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "iconv-lite": "0.6.3",
-        "jsonwebtoken": "9.0.3",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "mime-types": "3.0.2",
-        "n8n-workflow": "2.23.0",
-        "nanoid": "3.3.8",
-        "oauth-1.0a": "2.2.6",
-        "p-cancelable": "2.1.1",
-        "picocolors": "1.0.1",
-        "pretty-bytes": "5.6.0",
-        "proxy-from-env": "^1.1.0",
-        "qs": "6.14.2",
-        "ssh2": "1.15.0",
-        "uuid": "10.0.0",
-        "winston": "3.14.2",
-        "xml2js": "0.6.2"
-      },
-      "bin": {
-        "n8n-copy-static-files": "bin/copy-static-files",
-        "n8n-generate-metadata": "bin/generate-metadata",
-        "n8n-generate-node-defs": "bin/generate-node-defs",
-        "n8n-generate-translations": "bin/generate-translations"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/client-s3": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.808.0.tgz",
-      "integrity": "sha512-8RY3Jsm84twmYfiqnMkxznuY6pBX7y2GiuEJVdW1ZJLXRDOiCPkTBHsO6jUwppfMua7HRhO2OTAdWr7aSBAdPw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.808.0",
-        "@aws-sdk/credential-provider-node": "3.808.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
-        "@aws-sdk/middleware-expect-continue": "3.804.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.808.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-location-constraint": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-s3": "3.808.0",
-        "@aws-sdk/middleware-ssec": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.808.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/signature-v4-multi-region": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.808.0",
-        "@aws-sdk/xml-builder": "3.804.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.1",
-        "@smithy/eventstream-serde-browser": "^4.0.2",
-        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
-        "@smithy/eventstream-serde-node": "^4.0.2",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-blob-browser": "^4.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/hash-stream-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/md5-js": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.4",
-        "@smithy/middleware-retry": "^4.1.5",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.12",
-        "@smithy/util-defaults-mode-node": "^4.0.12",
-        "@smithy/util-endpoints": "^3.0.4",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
-      "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.804.0.tgz",
-      "integrity": "sha512-YW1hySBolALMII6C8y7Z0CRG2UX1dGJjLEBNFeefhO/xP7ZuE1dvnmfJGaEuBMnvc3wkRS63VZ3aqX6sevM1CA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
-      "integrity": "sha512-NW1yoTYDH2h8ycqMPNkvW3d1XT2vEeXfXclagL2tv82P7Qt7vPXYcObs/YtETvNZ7hdnmOftJ/IJv7YrFC8vtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.804.0.tgz",
-      "integrity": "sha512-AMtKnllIWKgoo7hiJfphLYotEwTERfjVMO2+cKAncz9w1g+bnYhHxiVhJJoR94y047c06X4PU5MsTxvdQ73Znw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.808.0.tgz",
-      "integrity": "sha512-qvyJTDf0HIsPpZzBUqhNQm5g8stAn2EOwVsaAolsOHuBsdaBAE/s/NgPzazDlSXwdF0ITvsIouUVDCn4fJGJqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/core": "^3.3.1",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.4",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.804.0.tgz",
-      "integrity": "sha512-Tk8jK0gOIUBvEPTz/wwSlP1V70zVQ3QYqsLPAjQRMO6zfOK9ax31dln3MgKvFDJxBydS2tS3wsn53v+brxDxTA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.808.0.tgz",
-      "integrity": "sha512-lQuEB6JK81eKV7fdiktmRq06Y1KCcJbx9fLf7b19nSfYUbJSn/kfSpHPv/tOkJK2HKnN61JsfG19YU8k4SOU8Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
-      "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@langchain/core": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
-      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
-      "license": "MIT",
-      "dependencies": {
-        "@cfworker/json-schema": "^4.0.2",
-        "@standard-schema/spec": "^1.1.0",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": ">=0.5.0 <1.0.0",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "uuid": "^11.1.0",
-        "zod": "^3.25.76 || ^4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@langchain/core/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@langchain/core/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/n8n-core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/n8n-core/node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/n8n-core/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/n8n-core/node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/n8n-core/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/n8n-core/node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/n8n-core/node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/n8n-core/node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/n8n-core/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/n8n-editor-ui": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-2.23.0.tgz",
-      "integrity": "sha512-sKX+33UKneD473Ip7Hn+RK/GujLR/UDvGEonWdCaHiqHFwKg8TK/j4Hl+MPT10/qgJNLDoziPKBA8YZeRZEcLw==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-2.26.1.tgz",
+      "integrity": "sha512-/Zh9oR1XNHivjX7I83GZW4TbxwP4822cJfwE07C3UYZ1UUkP6yAEFVFPVSJilwT4ma3G7Zn/fksU5EmyHcAVkA==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/n8n-nodes-base": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-2.23.0.tgz",
-      "integrity": "sha512-fTZjCagna3gH988ms71TGLWEfeYKFf9Rx41IV/T38m8A032OBzEX09+1x4TWXaYtRxtQdRnLs3pKeitjbfwBmA==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-2.26.1.tgz",
+      "integrity": "sha512-kuKaDHfFHWwH/M9cVzUhO5/DXZbxO8Ug/VhYaC0GiYcsFuVsiJdJDIQ+Xz1LsEoPCMdlmlh5x9NlZTW37Alnqw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.808.0",
         "@kafkajs/confluent-schema-registry": "3.8.0",
         "@mozilla/readability": "0.6.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@n8n/imap": "0.20.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/imap": "0.21.0",
         "@thednp/dommatrix": "^2.0.12",
         "alasql": "4.4.0",
         "amqplib": "0.10.6",
@@ -22243,7 +22792,7 @@
         "jsdom": "23.0.1",
         "jsonwebtoken": "9.0.3",
         "kafkajs": "2.2.4",
-        "ldapts": "4.2.6",
+        "ldapts": "8.1.7",
         "lodash": "4.18.1",
         "lossless-json": "1.0.5",
         "luxon": "3.7.2",
@@ -22255,7 +22804,7 @@
         "mqtt": "5.7.2",
         "mssql": "10.0.2",
         "mysql2": "3.17.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "node-html-markdown": "1.2.0",
         "node-ssh": "13.2.0",
         "nodemailer": "7.0.11",
@@ -22265,20 +22814,22 @@
         "pg": "8.17.0",
         "pg-promise": "11.9.1",
         "promise-ftp": "1.3.5",
+        "proxy-from-env": "^1.1.0",
         "redis": "4.6.14",
         "rfc2047": "4.0.1",
         "rhea": "3.0.4",
         "rrule": "2.8.1",
         "rss-parser": "3.13.0",
         "sanitize-html": "2.12.1",
-        "semver": "7.5.4",
+        "semver": "7.7.3",
         "showdown": "2.1.0",
         "simple-git": "3.36.0",
         "snowflake-sdk": "2.1.0",
         "ssh2-sftp-client": "12.1.0",
         "tmp-promise": "3.0.3",
         "ts-ics": "1.2.2",
-        "uuid": "10.0.0",
+        "undici": "^6.24.0",
+        "uuid": "11.1.1",
         "vm2": "3.11.5",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "xml2js": "0.6.2",
@@ -22395,6 +22946,43 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/n8n-nodes-base/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/n8n-nodes-base/node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -22497,6 +23085,36 @@
         }
       }
     },
+    "node_modules/n8n-nodes-base/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
     "node_modules/n8n-nodes-base/node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -22512,7 +23130,158 @@
         "parse5": "^6.0.1"
       }
     },
+    "node_modules/n8n-nodes-base/node_modules/ts-ics": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ts-ics/-/ts-ics-1.2.2.tgz",
+      "integrity": "sha512-L7T5JQi99qQ2Uv7AoCHUZ8Mx1bJYo7qBZtBckuHueR90I3WVdW5NC/tOqTVgu18c3zj08du+xlgWlTIcE+Foxw==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns-tz": "^2.0.0"
+      },
+      "peerDependencies": {
+        "date-fns": "^2",
+        "lodash": "^4",
+        "zod": "^3"
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/n8n-nodes-base/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/n8n-workflow": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.16.0.tgz",
+      "integrity": "sha512-JoDvHLvV4QZQBCDVQl5xkrGOmPmsacLO4TkJkErCzMmiEqIej+h14J6eCUY7gbxBj8V+GIBlpqyO63akJbXRQg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@n8n/errors": "0.6.0",
+        "@n8n/expression-runtime": "0.8.0",
+        "@n8n/tournament": "1.0.6",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.2",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.17.23",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "10.0.0",
+        "xml2js": "0.6.2",
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/@n8n/errors": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.6.0.tgz",
+      "integrity": "sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "callsites": "3.1.0"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/@n8n/expression-runtime": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.8.0.tgz",
+      "integrity": "sha512-SnBLoLsrGUCS9cVrF20UuSyKcMv+y6Clc4+EA9zLjX85S0GPwOAdApUVSsi81ejPAqMlm42TW1L6r7NpcK/ztQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
+      "dependencies": {
+        "@n8n/tournament": "1.0.6",
+        "isolated-vm": "^6.0.2",
+        "js-base64": "3.7.2",
+        "jssha": "3.3.1",
+        "lodash": "4.17.23",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/@n8n/tournament": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.0.6.tgz",
+      "integrity": "sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@n8n_io/riot-tmpl": "^4.0.1",
+        "ast-types": "^0.16.1",
+        "esprima-next": "^5.8.4",
+        "recast": "^0.22.0"
+      },
+      "engines": {
+        "node": ">=20.15",
+        "pnpm": ">=9.5"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/n8n-workflow/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/n8n-workflow/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
@@ -22522,41 +23291,242 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/n8n-workflow": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.23.0.tgz",
-      "integrity": "sha512-TCpVmYmpyb/jqmuRnXW9xh8wpcIK7ox1B45NVUiTOUwC79tBse2Ss0y486NetesOhiwU4cjYgjNDbTQPOcCW0w==",
+    "node_modules/n8n-workflow/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/n8n/node_modules/@aws-sdk/client-s3": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.808.0.tgz",
+      "integrity": "sha512-8RY3Jsm84twmYfiqnMkxznuY6pBX7y2GiuEJVdW1ZJLXRDOiCPkTBHsO6jUwppfMua7HRhO2OTAdWr7aSBAdPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+        "@aws-sdk/middleware-expect-continue": "3.804.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-location-constraint": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-sdk-s3": "3.808.0",
+        "@aws-sdk/middleware-ssec": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/signature-v4-multi-region": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@aws-sdk/xml-builder": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-blob-browser": "^4.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/hash-stream-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/md5-js": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/n8n/node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
+      "integrity": "sha512-NW1yoTYDH2h8ycqMPNkvW3d1XT2vEeXfXclagL2tv82P7Qt7vPXYcObs/YtETvNZ7hdnmOftJ/IJv7YrFC8vtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/n8n/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.808.0.tgz",
+      "integrity": "sha512-qvyJTDf0HIsPpZzBUqhNQm5g8stAn2EOwVsaAolsOHuBsdaBAE/s/NgPzazDlSXwdF0ITvsIouUVDCn4fJGJqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/n8n/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.808.0.tgz",
+      "integrity": "sha512-lQuEB6JK81eKV7fdiktmRq06Y1KCcJbx9fLf7b19nSfYUbJSn/kfSpHPv/tOkJK2HKnN61JsfG19YU8k4SOU8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/n8n/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
+      "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/n8n/node_modules/@langchain/core": {
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/n8n/node_modules/@langchain/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/n8n/node_modules/@n8n/api-types": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+      "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/errors": "0.8.0",
-        "@n8n/expression-runtime": "0.15.0",
-        "@n8n/tournament": "1.2.0",
-        "ast-types": "0.16.1",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.4",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "jsonrepair": "3.13.2",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "uuid": "10.0.0",
-        "xml2js": "0.6.2"
+        "@n8n/permissions": "0.63.0",
+        "n8n-workflow": "2.26.1",
+        "xss": "1.0.15"
       },
       "peerDependencies": {
         "zod": "3.25.67"
       }
     },
-    "node_modules/n8n-workflow/node_modules/form-data": {
+    "node_modules/n8n/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/n8n/node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/n8n/node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
@@ -22572,30 +23542,210 @@
         "node": ">= 6"
       }
     },
-    "node_modules/n8n-workflow/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+    "node_modules/n8n/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/n8n/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/n8n/node_modules/n8n-core": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.26.1.tgz",
+      "integrity": "sha512-X0IO6e89aGVA3PUPz0YhE/CwHoipeHaGBVlFs0FHEq+DZq5D21HQkbHT89+OBQLM58Vd5fGE0ceITgeeaSbhPA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.808.0",
+        "@langchain/core": "1.1.41",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/workflow-sdk": "0.19.1",
+        "@sentry/node": "^10.55.0",
+        "@sentry/node-native": "^10.55.0",
+        "@sentry/profiling-node": "^10.55.0",
+        "axios": "1.16.1",
+        "cache-manager": "5.2.3",
+        "callsites": "3.1.0",
+        "chardet": "2.0.0",
+        "cron": "4.4.0",
+        "fast-glob": "3.2.12",
+        "file-type": "16.5.4",
+        "form-data": "4.0.4",
+        "htmlparser2": "^10.0.0",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "iconv-lite": "0.6.3",
+        "jsonwebtoken": "9.0.3",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "mime-types": "3.0.2",
+        "n8n-workflow": "2.26.1",
+        "nanoid": "3.3.8",
+        "oauth-1.0a": "2.2.6",
+        "p-cancelable": "2.1.1",
+        "picocolors": "1.0.1",
+        "pretty-bytes": "5.6.0",
+        "proxy-from-env": "^1.1.0",
+        "qs": "6.14.2",
+        "ssh2": "1.15.0",
+        "uuid": "11.1.1",
+        "winston": "3.14.2",
+        "xml2js": "0.6.2"
+      },
+      "bin": {
+        "n8n-copy-static-files": "bin/copy-static-files",
+        "n8n-generate-metadata": "bin/generate-metadata",
+        "n8n-generate-node-defs": "bin/generate-node-defs",
+        "n8n-generate-translations": "bin/generate-translations"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/n8n/node_modules/n8n-core/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/n8n/node_modules/n8n-workflow": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+      "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/tournament": "1.3.0",
+        "ast-types": "0.16.1",
+        "callsites": "3.1.0",
+        "esprima-next": "5.8.4",
+        "form-data": "4.0.4",
+        "jmespath": "0.16.0",
+        "js-base64": "3.7.8",
+        "jsonrepair": "3.13.2",
+        "jssha": "3.3.1",
+        "lodash": "4.18.1",
+        "luxon": "3.7.2",
+        "md5": "2.3.0",
+        "recast": "0.22.0",
+        "title-case": "3.0.3",
+        "transliteration": "2.3.5",
+        "uuid": "11.1.1",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
+      }
+    },
+    "node_modules/n8n/node_modules/ssh2": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.9",
+        "nan": "^2.18.0"
+      }
+    },
+    "node_modules/n8n/node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/n8n/node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/n8n/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
-    "node_modules/n8n/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/n8n/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/n8n/node_modules/zod-to-json-schema": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.23.3"
       }
     },
     "node_modules/named-placeholders": {
@@ -23124,9 +24274,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "license": "MIT"
     },
     "node_modules/oauth-1.0a": {
@@ -23136,9 +24286,9 @@
       "license": "MIT"
     },
     "node_modules/oauth4webapi": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.7.0.tgz",
-      "integrity": "sha512-Q52wTPUWPsVLVVmTViXPQFMW2h2xv2jnDGxypjpelCFKaOjLsm7AxYuOk1oQgFm95VNDbuggasu9htXrz6XwKw==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -23299,26 +24449,13 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
       "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "ws": {
@@ -23329,37 +24466,6 @@
         }
       }
     },
-    "node_modules/openai/node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/openai/node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/openai/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
@@ -23367,13 +24473,13 @@
       "license": "MIT"
     },
     "node_modules/openid-client": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.5.0.tgz",
-      "integrity": "sha512-fAfYaTnOYE2kQCqEJGX9KDObW2aw7IQy4jWpU/+3D3WoCFLbix5Hg6qIPQ6Js9r7f8jDUmsnnguRNCSw4wU/IQ==",
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
       "license": "MIT",
       "dependencies": {
-        "jose": "^6.0.10",
-        "oauth4webapi": "^3.5.1"
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -25341,27 +26447,12 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -26193,9 +27284,9 @@
       }
     },
     "node_modules/ssh2": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
-      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
       "hasInstallScript": true,
       "dependencies": {
         "asn1": "^0.2.6",
@@ -26205,8 +27296,8 @@
         "node": ">=10.16.0"
       },
       "optionalDependencies": {
-        "cpu-features": "~0.0.9",
-        "nan": "^2.18.0"
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/ssh2-sftp-client": {
@@ -26224,23 +27315,6 @@
       "funding": {
         "type": "individual",
         "url": "https://square.link/u/4g7sPflL"
-      }
-    },
-    "node_modules/ssh2-sftp-client/node_modules/ssh2": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
-      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "asn1": "^0.2.6",
-        "bcrypt-pbkdf": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      },
-      "optionalDependencies": {
-        "cpu-features": "~0.0.10",
-        "nan": "^2.23.0"
       }
     },
     "node_modules/sshpk": {
@@ -26455,18 +27529,19 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -26476,15 +27551,15 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -26742,9 +27817,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -27146,15 +28221,16 @@
       }
     },
     "node_modules/thrift": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.21.0.tgz",
-      "integrity": "sha512-AW8rwHYjeqXisS8B1iwko2gkNMFwSRJ+bO/W0xTGqRspTD3lGHwZx438+pHdOJ3GwpRAnK7TKbjqPOrHAa7ZwQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.23.0.tgz",
+      "integrity": "sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
         "q": "^1.5.0",
+        "uuid": "^13.0.0",
         "ws": "^5.2.3"
       },
       "engines": {
@@ -27168,6 +28244,19 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
+      }
+    },
+    "node_modules/thrift/node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/thrift/node_modules/ws": {
@@ -27198,9 +28287,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -27368,20 +28457,6 @@
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
     },
-    "node_modules/ts-ics": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-ics/-/ts-ics-1.2.2.tgz",
-      "integrity": "sha512-L7T5JQi99qQ2Uv7AoCHUZ8Mx1bJYo7qBZtBckuHueR90I3WVdW5NC/tOqTVgu18c3zj08du+xlgWlTIcE+Foxw==",
-      "license": "MIT",
-      "dependencies": {
-        "date-fns-tz": "^2.0.0"
-      },
-      "peerDependencies": {
-        "date-fns": "^2",
-        "lodash": "^4",
-        "zod": "^3"
-      }
-    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -27447,16 +28522,6 @@
         "node": ">=18",
         "npm": ">=9"
       }
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "node_modules/tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -27566,17 +28631,17 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -27904,12 +28969,18 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utilium": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/utilium/-/utilium-1.10.1.tgz",
-      "integrity": "sha512-GQINDTb/ocyz4acQj3GXAe0wipYxws6L+9ouqaq10KlInTk9DGvW9TJd0pYa/Xu3cppNnZuB4T/sBuSXpcN2ng==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/utilium/-/utilium-3.2.0.tgz",
+      "integrity": "sha512-+3bEeQPKMWRIlT9/lXXCzMoVzZt9eU9DAZ4Avi2YeXrO/Ur7O7dEW8seCz0tchSatCVnvKZ+Nd70q7X3CK/OFw==",
+      "license": "LGPL-3.0-or-later",
       "dependencies": {
         "eventemitter3": "^5.0.1"
+      },
+      "bin": {
+        "lice": "scripts/lice.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       },
       "funding": {
         "type": "individual",
@@ -28200,9 +29271,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -28727,9 +29798,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -28745,13 +29816,22 @@
         "zod": "^3.24.2"
       }
     },
+    "node_modules/zod-from-json-schema-v3/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zod-to-json-schema": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
-      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.23.3"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {
@@ -28789,76 +29869,37 @@
       }
     },
     "@ai-sdk/amazon-bedrock": {
-      "version": "4.0.108",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.108.tgz",
-      "integrity": "sha512-cVAzseR9OoSSL7966TMj2uUbDOL2e1LaH2JXrWvyMXQvF5Me2rPfzdA06k/vhYjP0DQq1uvsZPRojmg4ghiI9g==",
+      "version": "4.0.114",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-4.0.114.tgz",
+      "integrity": "sha512-s3ajs4hlAdb+5A58O423OY0zEcNfsjgGLv+GkbwZegjcvvfESyoH2CzZnG321Fjzr79nKpo7PQsVFxMZcWwFaQ==",
       "requires": {
-        "@ai-sdk/anthropic": "3.0.79",
+        "@ai-sdk/anthropic": "3.0.82",
+        "@ai-sdk/openai": "3.0.69",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@smithy/eventstream-codec": "^4.0.1",
         "@smithy/util-utf8": "^4.0.0",
         "aws4fetch": "^1.0.20"
-      },
-      "dependencies": {
-        "@ai-sdk/anthropic": {
-          "version": "3.0.79",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.79.tgz",
-          "integrity": "sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==",
-          "requires": {
-            "@ai-sdk/provider": "3.0.10",
-            "@ai-sdk/provider-utils": "4.0.27"
-          }
-        },
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/anthropic": {
-      "version": "3.0.58",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.58.tgz",
-      "integrity": "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q==",
+      "version": "3.0.82",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.82.tgz",
+      "integrity": "sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A==",
       "requires": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.19"
-      },
-      "dependencies": {
-        "@ai-sdk/provider-utils": {
-          "version": "4.0.19",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
-          "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
-          "requires": {
-            "@ai-sdk/provider": "3.0.8",
-            "@standard-schema/spec": "^1.1.0",
-            "eventsource-parser": "^3.0.6"
-          }
-        }
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       }
     },
     "@ai-sdk/azure": {
-      "version": "3.0.66",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-3.0.66.tgz",
-      "integrity": "sha512-V3AjjnRMoKgBK/cxE8hb8/VxsBKV9bIdWwSZKE2mfEH0O599X1Pk6FwcOY+NM3e7sdyXhLjbIgaJCnZkdFH94g==",
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/azure/-/azure-3.0.72.tgz",
+      "integrity": "sha512-uGyTz78k7qhUrvwNhivvgKZCvLQeX7DpEZgpmFkOfTmWQT7e4q+pRSu3V0zc9BmUamc0OuCRl09bdeLkBlmnsw==",
       "requires": {
-        "@ai-sdk/openai": "3.0.65",
+        "@ai-sdk/deepseek": "2.0.36",
+        "@ai-sdk/openai": "3.0.69",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/cohere": {
@@ -28868,74 +29909,34 @@
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/deepseek": {
-      "version": "2.0.35",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.35.tgz",
-      "integrity": "sha512-9DhYurbAvcurOEGN6u2myYDybrrzGfcrkG8hwmFjwTrePW6KCMggm0YxP7e8RkLYcQKqCEMgFlyEB4BM6EmiKg==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.36.tgz",
+      "integrity": "sha512-7K0iMfNCpJgU8sxpBb7iuxZdjRIJO2ooGH/DkDLU9FKFwhVYBHvL145AgtPjJjle1PGJLGBg5as3PMt24IBuVw==",
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/gateway": {
-      "version": "3.0.120",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.120.tgz",
-      "integrity": "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==",
+      "version": "3.0.127",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.127.tgz",
+      "integrity": "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==",
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@vercel/oidc": "3.2.0"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/google": {
-      "version": "3.0.79",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.79.tgz",
-      "integrity": "sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==",
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.80.tgz",
+      "integrity": "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==",
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/groq": {
@@ -28945,16 +29946,6 @@
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/mistral": {
@@ -28964,41 +29955,30 @@
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/openai": {
-      "version": "3.0.65",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.65.tgz",
-      "integrity": "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==",
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.69.tgz",
+      "integrity": "sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==",
       "requires": {
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
+      }
+    },
+    "@ai-sdk/openai-compatible": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.48.tgz",
+      "integrity": "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==",
+      "requires": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       }
     },
     "@ai-sdk/provider": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
-      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "requires": {
         "json-schema": "^0.4.0"
       }
@@ -29011,45 +29991,16 @@
         "@ai-sdk/provider": "3.0.10",
         "@standard-schema/spec": "^1.1.0",
         "eventsource-parser": "^3.0.8"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@ai-sdk/xai": {
-      "version": "3.0.92",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-3.0.92.tgz",
-      "integrity": "sha512-yqRMdEVfSkZCXs5mqeKfYOuQElo93igwz/4zWbYkhZWAW7tDh+5uqRef6MtQVYF/bTC1EsdbeO9DtsOtAZMOLA==",
+      "version": "3.0.93",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-3.0.93.tgz",
+      "integrity": "sha512-HxazLIcSTgI0UQoq6ua0rcSR8+eXuNy0Qh4jkCY9EAWedYn6CQ0XD/j34U4/JYtO738xJdY+tE95okdqWqXkHA==",
       "requires": {
         "@ai-sdk/openai-compatible": "2.0.48",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27"
-      },
-      "dependencies": {
-        "@ai-sdk/openai-compatible": {
-          "version": "2.0.48",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.48.tgz",
-          "integrity": "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==",
-          "requires": {
-            "@ai-sdk/provider": "3.0.10",
-            "@ai-sdk/provider-utils": "4.0.27"
-          }
-        },
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "@anthropic-ai/sdk": {
@@ -29246,1069 +30197,1231 @@
         }
       }
     },
-    "@aws-sdk/client-bedrock-agent-runtime": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.1054.0.tgz",
-      "integrity": "sha512-buKSmh/GJNvP9r9Ghx9nl6QPju3zRvLgX3WNKJztDWxoEe1WJAkL0Kh37P3JMQ2SWxx+JrSKQvuwF/4jY60mkQ==",
+    "@aws-sdk/checksums": {
+      "version": "3.1000.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.4.tgz",
+      "integrity": "sha512-Pt1JEVLu02jTWzpcUzUHciiWScyZg3JpHCTB1h9DtDPWY3dBufBnFJAevVHali/bAkmMdMhYUD8tH/VvPuBkUg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
             "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+          "requires": {
+            "@smithy/types": "^4.14.3",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-bedrock-agent-runtime": {
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agent-runtime/-/client-bedrock-agent-runtime-3.1065.0.tgz",
+      "integrity": "sha512-QJdLzsVWMA38y5dxEZcj1St7i1JVinQtBabEQlmv7WWzcTKG7HjPevArRl+InIlMrzEX41s8MnCOmp1n4kbA9g==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/core": {
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+          "requires": {
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
+            "@aws/lambda-invoke-store": "^0.2.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+          "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+          "version": "3.972.48",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+          "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+          "version": "3.972.52",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+          "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-login": "^3.972.51",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+          "version": "3.972.54",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+          "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-ini": "^3.972.52",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+          "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+          "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/token-providers": "3.1065.0",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+          "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+          "version": "3.997.19",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+          "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+          "version": "3.1065.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+          "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1054.0.tgz",
-      "integrity": "sha512-APBAWir5vHzUWZ11bHfG3fXJ9t359bcwehwLTScpiYwmUydw7DqH76RAbtiYSstrV76hJ1v3pHM8pGk//E/0uw==",
+      "version": "3.938.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.938.0.tgz",
+      "integrity": "sha512-LMr4eWwET3mCQKsk3rbKKvUQCMuyeqdqNuJ8+NGVv2CgSdnlW9Dl6IMXiF7yGDgQaQxlGRthp+EogNTC562NZQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/eventstream-handler-node": "^3.972.17",
-        "@aws-sdk/middleware-eventstream": "^3.972.13",
-        "@aws-sdk/middleware-websocket": "^3.972.22",
-        "@aws-sdk/token-providers": "3.1054.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.936.0",
+        "@aws-sdk/credential-provider-node": "3.936.0",
+        "@aws-sdk/eventstream-handler-node": "3.936.0",
+        "@aws-sdk/middleware-eventstream": "3.936.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.936.0",
+        "@aws-sdk/middleware-websocket": "3.936.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/token-providers": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+        "@aws-sdk/client-sso": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.936.0.tgz",
+          "integrity": "sha512-0G73S2cDqYwJVvqL08eakj79MZG2QRaB56Ul8/Ps9oQxllr7DMI1IQ/N3j3xjxgpq/U36pkoFZ8aK1n7Sbr3IQ==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/middleware-host-header": "3.936.0",
+            "@aws-sdk/middleware-logger": "3.936.0",
+            "@aws-sdk/middleware-recursion-detection": "3.936.0",
+            "@aws-sdk/middleware-user-agent": "3.936.0",
+            "@aws-sdk/region-config-resolver": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@aws-sdk/util-endpoints": "3.936.0",
+            "@aws-sdk/util-user-agent-browser": "3.936.0",
+            "@aws-sdk/util-user-agent-node": "3.936.0",
+            "@smithy/config-resolver": "^4.4.3",
+            "@smithy/core": "^3.18.5",
+            "@smithy/fetch-http-handler": "^5.3.6",
+            "@smithy/hash-node": "^4.2.5",
+            "@smithy/invalid-dependency": "^4.2.5",
+            "@smithy/middleware-content-length": "^4.2.5",
+            "@smithy/middleware-endpoint": "^4.3.12",
+            "@smithy/middleware-retry": "^4.4.12",
+            "@smithy/middleware-serde": "^4.2.6",
+            "@smithy/middleware-stack": "^4.2.5",
+            "@smithy/node-config-provider": "^4.3.5",
+            "@smithy/node-http-handler": "^4.4.5",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/smithy-client": "^4.9.8",
+            "@smithy/types": "^4.9.0",
+            "@smithy/url-parser": "^4.2.5",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-body-length-browser": "^4.2.0",
+            "@smithy/util-body-length-node": "^4.2.1",
+            "@smithy/util-defaults-mode-browser": "^4.3.11",
+            "@smithy/util-defaults-mode-node": "^4.2.14",
+            "@smithy/util-endpoints": "^3.2.5",
+            "@smithy/util-middleware": "^4.2.5",
+            "@smithy/util-retry": "^4.2.5",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.936.0.tgz",
+          "integrity": "sha512-eGJ2ySUMvgtOziHhDRDLCrj473RJoL4J1vPjVM3NrKC/fF3/LoHjkut8AAnKmrW6a2uTzNKubigw8dEnpmpERw==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@aws-sdk/xml-builder": "3.930.0",
+            "@smithy/core": "^3.18.5",
+            "@smithy/node-config-provider": "^4.3.5",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/signature-v4": "^5.3.5",
+            "@smithy/smithy-client": "^4.9.8",
+            "@smithy/types": "^4.9.0",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-middleware": "^4.2.5",
+            "@smithy/util-utf8": "^4.2.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.936.0.tgz",
+          "integrity": "sha512-dKajFuaugEA5i9gCKzOaVy9uTeZcApE+7Z5wdcZ6j40523fY1a56khDAUYkCfwqa7sHci4ccmxBkAo+fW1RChA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.936.0.tgz",
+          "integrity": "sha512-5FguODLXG1tWx/x8fBxH+GVrk7Hey2LbXV5h9SFzYCx/2h50URBm0+9hndg0Rd23+xzYe14F6SI9HA9c1sPnjg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/fetch-http-handler": "^5.3.6",
+            "@smithy/node-http-handler": "^4.4.5",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/smithy-client": "^4.9.8",
+            "@smithy/types": "^4.9.0",
+            "@smithy/util-stream": "^4.5.6",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.936.0.tgz",
+          "integrity": "sha512-TbUv56ERQQujoHcLMcfL0Q6bVZfYF83gu/TjHkVkdSlHPOIKaG/mhE2XZSQzXv1cud6LlgeBbfzVAxJ+HPpffg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/credential-provider-env": "3.936.0",
+            "@aws-sdk/credential-provider-http": "3.936.0",
+            "@aws-sdk/credential-provider-login": "3.936.0",
+            "@aws-sdk/credential-provider-process": "3.936.0",
+            "@aws-sdk/credential-provider-sso": "3.936.0",
+            "@aws-sdk/credential-provider-web-identity": "3.936.0",
+            "@aws-sdk/nested-clients": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/credential-provider-imds": "^4.2.5",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-login": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.936.0.tgz",
+          "integrity": "sha512-8DVrdRqPyUU66gfV7VZNToh56ZuO5D6agWrkLQE/xbLJOm2RbeRgh6buz7CqV8ipRd6m+zCl9mM4F3osQLZn8Q==",
+          "requires": {
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/nested-clients": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.936.0.tgz",
+          "integrity": "sha512-rk/2PCtxX9xDsQW8p5Yjoca3StqmQcSfkmD7nQ61AqAHL1YgpSQWqHE+HjfGGiHDYKG7PvE33Ku2GyA7lEIJAw==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/credential-provider-env": "3.936.0",
+            "@aws-sdk/credential-provider-http": "3.936.0",
+            "@aws-sdk/credential-provider-ini": "3.936.0",
+            "@aws-sdk/credential-provider-process": "3.936.0",
+            "@aws-sdk/credential-provider-sso": "3.936.0",
+            "@aws-sdk/credential-provider-web-identity": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/credential-provider-imds": "^4.2.5",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.936.0.tgz",
+          "integrity": "sha512-GpA4AcHb96KQK2PSPUyvChvrsEKiLhQ5NWjeef2IZ3Jc8JoosiedYqp6yhZR+S8cTysuvx56WyJIJc8y8OTrLA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.936.0.tgz",
+          "integrity": "sha512-wHlEAJJvtnSyxTfNhN98JcU4taA1ED2JvuI2eePgawqBwS/Tzi0mhED1lvNIaWOkjfLd+nHALwszGrtJwEq4yQ==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/client-sso": "3.936.0",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/token-providers": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.936.0.tgz",
+          "integrity": "sha512-v3qHAuoODkoRXsAF4RG+ZVO6q2P9yYBT4GMpMEfU9wXVNn7AIfwZgTwzSUfnjNiGva5BKleWVpRpJ9DeuLFbUg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/nested-clients": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+          "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+          "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+          "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@aws/lambda-invoke-store": "^0.2.0",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.936.0.tgz",
+          "integrity": "sha512-YB40IPa7K3iaYX0lSnV9easDOLPLh+fJyUDF3BH8doX4i1AOSsYn86L4lVldmOaSX+DwiaqKHpvk4wPBdcIPWw==",
+          "requires": {
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@aws-sdk/util-endpoints": "3.936.0",
+            "@smithy/core": "^3.18.5",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.936.0.tgz",
+          "integrity": "sha512-eyj2tz1XmDSLSZQ5xnB7cLTVKkSJnYAEoNDSUNhzWPxrBDYeJzIbatecOKceKCU8NBf8gWWZCK/CSY0mDxMO0A==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/middleware-host-header": "3.936.0",
+            "@aws-sdk/middleware-logger": "3.936.0",
+            "@aws-sdk/middleware-recursion-detection": "3.936.0",
+            "@aws-sdk/middleware-user-agent": "3.936.0",
+            "@aws-sdk/region-config-resolver": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@aws-sdk/util-endpoints": "3.936.0",
+            "@aws-sdk/util-user-agent-browser": "3.936.0",
+            "@aws-sdk/util-user-agent-node": "3.936.0",
+            "@smithy/config-resolver": "^4.4.3",
+            "@smithy/core": "^3.18.5",
+            "@smithy/fetch-http-handler": "^5.3.6",
+            "@smithy/hash-node": "^4.2.5",
+            "@smithy/invalid-dependency": "^4.2.5",
+            "@smithy/middleware-content-length": "^4.2.5",
+            "@smithy/middleware-endpoint": "^4.3.12",
+            "@smithy/middleware-retry": "^4.4.12",
+            "@smithy/middleware-serde": "^4.2.6",
+            "@smithy/middleware-stack": "^4.2.5",
+            "@smithy/node-config-provider": "^4.3.5",
+            "@smithy/node-http-handler": "^4.4.5",
+            "@smithy/protocol-http": "^5.3.5",
+            "@smithy/smithy-client": "^4.9.8",
+            "@smithy/types": "^4.9.0",
+            "@smithy/url-parser": "^4.2.5",
+            "@smithy/util-base64": "^4.3.0",
+            "@smithy/util-body-length-browser": "^4.2.0",
+            "@smithy/util-body-length-node": "^4.2.1",
+            "@smithy/util-defaults-mode-browser": "^4.3.11",
+            "@smithy/util-defaults-mode-node": "^4.2.14",
+            "@smithy/util-endpoints": "^3.2.5",
+            "@smithy/util-middleware": "^4.2.5",
+            "@smithy/util-retry": "^4.2.5",
+            "@smithy/util-utf8": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/region-config-resolver": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+          "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/config-resolver": "^4.4.3",
+            "@smithy/node-config-provider": "^4.3.5",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.936.0.tgz",
+          "integrity": "sha512-vvw8+VXk0I+IsoxZw0mX9TMJawUJvEsg3EF7zcCSetwhNPAU8Xmlhv7E/sN/FgSmm7b7DsqKoW6rVtQiCs1PWQ==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "3.936.0",
+            "@aws-sdk/nested-clients": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/property-provider": "^4.2.5",
+            "@smithy/shared-ini-file-loader": "^4.4.0",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+          "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+          "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/types": "^4.9.0",
+            "@smithy/url-parser": "^4.2.5",
+            "@smithy/util-endpoints": "^3.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+          "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+          "requires": {
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/types": "^4.9.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.936.0.tgz",
+          "integrity": "sha512-XOEc7PF9Op00pWV2AYCGDSu5iHgYjIO53Py2VUQTIvP7SRCaCsXmA33mjBvC2Ms6FhSyWNa4aK4naUGIz0hQcw==",
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.936.0",
+            "@aws-sdk/types": "3.936.0",
+            "@smithy/node-config-provider": "^4.3.5",
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/xml-builder": {
+          "version": "3.930.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+          "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+          "requires": {
+            "@smithy/types": "^4.9.0",
+            "fast-xml-parser": "5.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "5.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+          "requires": {
+            "strnum": "^2.1.0"
+          }
+        },
+        "strnum": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+          "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+          "requires": {
+            "anynum": "^1.0.0"
           }
         }
       }
     },
     "@aws-sdk/client-cognito-identity": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1054.0.tgz",
-      "integrity": "sha512-B3R1BnF9MtyAyIhI875geixK4SJ1dXwWjf8McBMyMkctaXdvGx5O4YD7MPxGPtbmExrW4tDp6h4wQbDJDLZumw==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.808.0.tgz",
+      "integrity": "sha512-M9pdFQ+Efl1O4No6R7uMEOkidKVUiNsmN13EyzuIOGech9g+RF+LgDn3n8+PuC7EIgndQVe6sQ6w39sPQdBkww==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.808.0",
+        "@aws-sdk/region-config-resolver": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.808.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.808.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.4",
+        "@smithy/middleware-retry": "^4.1.5",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.4",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.12",
+        "@smithy/util-defaults-mode-node": "^4.0.12",
+        "@smithy/util-endpoints": "^3.0.4",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-          "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/client-kendra": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kendra/-/client-kendra-3.1054.0.tgz",
-      "integrity": "sha512-pIM4br1YF6JzzmwPKP/hHXV+OYd6E0FQ18DwmG/j4ayuwmgxuQqemvyXYb6saNwLoc7RuYLzKu74C2E/bnDAVQ==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kendra/-/client-kendra-3.1065.0.tgz",
+      "integrity": "sha512-/5SwiGP4KvlAE3mfMlIN/x+W0tP43+K5QU/vu7LPdIsBn65+T0ZAA1yGqlKPZsVlsLnEBzt/mDRdNjgOdX68nA==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
             "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+          "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+          "version": "3.972.48",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+          "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+          "version": "3.972.52",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+          "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-login": "^3.972.51",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+          "version": "3.972.54",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+          "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-ini": "^3.972.52",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+          "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+          "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/token-providers": "3.1065.0",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+          "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+          "version": "3.997.19",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+          "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+          "version": "3.1065.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+          "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1054.0.tgz",
-      "integrity": "sha512-2ue7uVqaHYX4rytkcrLySYU/m/ZlRbL8KojWefbR24B0/TcFkqN2IovpBFrnmla/dtZAn9eVSlhHeEddOghZ5w==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1065.0.tgz",
+      "integrity": "sha512-KtCpg2vihUjhUpqpsZIcB6Dm1hv9lRn5hWwU6hXtYfSQionFD/dB/gTwgyn9AHX6eGiCFqHfjIZwETz5Cz4RWA==",
       "requires": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.16",
-        "@aws-sdk/middleware-expect-continue": "^3.972.13",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.22",
-        "@aws-sdk/middleware-location-constraint": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.43",
-        "@aws-sdk/middleware-ssec": "^3.972.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.29",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.50",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
             "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+          "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+          "version": "3.972.48",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+          "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+          "version": "3.972.52",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+          "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-login": "^3.972.51",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+          "version": "3.972.54",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+          "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-ini": "^3.972.52",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+          "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+          "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/token-providers": "3.1065.0",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+          "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+          "version": "3.997.19",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+          "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+          "version": "3.1065.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+          "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/client-sagemaker": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker/-/client-sagemaker-3.1054.0.tgz",
-      "integrity": "sha512-w8N6X1nki89KFFEiTnj/hj5ZMqQAx7WKj1izmwZNs+qfz3yTyPppImh1bCIB7K4Bj8B103wIixzxjJsoEIE/XQ==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker/-/client-sagemaker-3.1065.0.tgz",
+      "integrity": "sha512-m0JxViZrQR/kX3gl0sENOHcVRBzvCiEZxQBWKdMaS8lSBIRniE6IIrPeuKhjLVb4+IIwXueDLr1MzTApd4gLDA==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/node-http-handler": "^4.7.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
             "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+          "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
+          "version": "3.972.48",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+          "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
+          "version": "3.972.52",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+          "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-login": "^3.972.51",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
+          "version": "3.972.54",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+          "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/credential-provider-env": "^3.972.46",
+            "@aws-sdk/credential-provider-http": "^3.972.48",
+            "@aws-sdk/credential-provider-ini": "^3.972.52",
+            "@aws-sdk/credential-provider-process": "^3.972.46",
+            "@aws-sdk/credential-provider-sso": "^3.972.51",
+            "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/credential-provider-imds": "^4.3.7",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
+          "version": "3.972.46",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+          "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+          "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/token-providers": "3.1065.0",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
+          "version": "3.972.51",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+          "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+          "version": "3.997.19",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+          "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
+          "version": "3.1065.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+          "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
           "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/nested-clients": "^3.997.19",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
@@ -30471,68 +31584,16 @@
         "tslib": "^2.6.2"
       }
     },
-    "@aws-sdk/crc64-nvme": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
-      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
-      "requires": {
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      }
-    },
     "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.37.tgz",
-      "integrity": "sha512-f8ZRPoATqSVS1LW19KwiWn2/BSTdylXPznAjDI2r7d3+RT880/yRT9uBQhPE+Ba986LiMRvg1AhmFYDwNLk/0A==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.808.0.tgz",
+      "integrity": "sha512-AbsD/qHyQmyZ+CqJNOaGlnwZaXu8HfndfEiLsIJU/dIf9Wbt7ZtsHSAI/x78awxGohDneMZ6c5vuaRGYL7Z04g==",
       "requires": {
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/client-cognito-identity": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-          "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-env": {
@@ -30585,56 +31646,56 @@
       }
     },
     "@aws-sdk/credential-provider-login": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.44.tgz",
-      "integrity": "sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
+      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
       "requires": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
             "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
+          "version": "3.997.19",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+          "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
+            "@aws-sdk/core": "^3.974.20",
+            "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+            "@aws-sdk/types": "^3.973.12",
+            "@smithy/core": "^3.24.6",
+            "@smithy/fetch-http-handler": "^5.4.6",
+            "@smithy/node-http-handler": "^4.7.6",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
@@ -30701,217 +31762,60 @@
       }
     },
     "@aws-sdk/credential-providers": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1054.0.tgz",
-      "integrity": "sha512-/tK0QmOL1vUqOgqRMLTJlvHRAp+7GTfdPgrfgD5T0WBmExdlaFsVwzR7mUQlmYoY8mExqoRH4UEt2I3snsMLrg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.808.0.tgz",
+      "integrity": "sha512-JJvY/gcet+tFw7dGifhTMJ2jfLXCJBR2Tu2rY/ePi+HVUrR//TnWmcm8qGvT1nWiCQ7w9NEhMlJgqKEIM/MkVQ==",
       "requires": {
-        "@aws-sdk/client-cognito-identity": "3.1054.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.37",
-        "@aws-sdk/credential-provider-env": "^3.972.40",
-        "@aws-sdk/credential-provider-http": "^3.972.42",
-        "@aws-sdk/credential-provider-ini": "^3.972.44",
-        "@aws-sdk/credential-provider-login": "^3.972.44",
-        "@aws-sdk/credential-provider-node": "^3.972.45",
-        "@aws-sdk/credential-provider-process": "^3.972.40",
-        "@aws-sdk/credential-provider-sso": "^3.972.44",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-        "@aws-sdk/nested-clients": "^3.997.12",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/client-cognito-identity": "3.808.0",
+        "@aws-sdk/core": "3.808.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.808.0",
+        "@aws-sdk/credential-provider-env": "3.808.0",
+        "@aws-sdk/credential-provider-http": "3.808.0",
+        "@aws-sdk/credential-provider-ini": "3.808.0",
+        "@aws-sdk/credential-provider-node": "3.808.0",
+        "@aws-sdk/credential-provider-process": "3.808.0",
+        "@aws-sdk/credential-provider-sso": "3.808.0",
+        "@aws-sdk/credential-provider-web-identity": "3.808.0",
+        "@aws-sdk/nested-clients": "3.808.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/core": "^3.3.1",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-          "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.40.tgz",
-          "integrity": "sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.972.42",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.42.tgz",
-          "integrity": "sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.44.tgz",
-          "integrity": "sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-login": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.972.45",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.45.tgz",
-          "integrity": "sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "^3.972.40",
-            "@aws-sdk/credential-provider-http": "^3.972.42",
-            "@aws-sdk/credential-provider-ini": "^3.972.44",
-            "@aws-sdk/credential-provider-process": "^3.972.40",
-            "@aws-sdk/credential-provider-sso": "^3.972.44",
-            "@aws-sdk/credential-provider-web-identity": "^3.972.44",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/credential-provider-imds": "^4.3.2",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.972.40",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.40.tgz",
-          "integrity": "sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.44.tgz",
-          "integrity": "sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/token-providers": "3.1054.0",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.972.44",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.44.tgz",
-          "integrity": "sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.997.12",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.12.tgz",
-          "integrity": "sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/fetch-http-handler": "^5.4.3",
-            "@smithy/node-http-handler": "^4.7.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.1054.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz",
-          "integrity": "sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==",
-          "requires": {
-            "@aws-sdk/core": "^3.974.14",
-            "@aws-sdk/nested-clients": "^3.997.12",
-            "@aws-sdk/types": "^3.973.9",
-            "@smithy/core": "^3.24.3",
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
-      "integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.936.0.tgz",
+      "integrity": "sha512-4zIbhdRmol2KosIHmU31ATvNP0tkJhDlRj9GuawVJoEnMvJA1pd2U3SRdiOImJU3j8pT46VeS4YMmYxfjGHByg==",
       "requires": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/eventstream-codec": "^4.2.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+          "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/lib-storage": {
-      "version": "3.1054.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1054.0.tgz",
-      "integrity": "sha512-cnEZOTWnfRDS5wpCT6yVgQai16R+qhC5E9p1wfmjwj4H4YfI0dVq7I2zUZjUjb4Pfy0dIziCuwQg1jEVQzW/Ew==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1065.0.tgz",
+      "integrity": "sha512-0eEVoAWuvob9BkiKc/jtFPaOQYR7hbW6xioTe3b1U1WpwyVLKO6KROdm1zpMC7k5EOpVDhdFXkqZvFSCJuc4Uw==",
       "requires": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -30919,127 +31823,59 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.16.tgz",
-      "integrity": "sha512-FhasMTBDBmMN7EEa1hUeHwo5p5Mv3Dm8w0VEbdXX/6ola/uyhRuJt8zGkH09mLTmab20USTzEpPqyqEoe1MqNg==",
+      "version": "3.808.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
+      "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
       "requires": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-          "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-eventstream": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
-      "integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.936.0.tgz",
+      "integrity": "sha512-XQSH8gzLkk8CDUDxyt4Rdm9owTpRIPdtg2yw9Y2Wl5iSI55YQSiC3x8nM3c4Y4WqReJprunFPK225ZUDoYCfZA==",
       "requires": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+          "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.13.tgz",
-      "integrity": "sha512-sHiqIFg8o2ipT7t40B89Vj0ubSUtY6OSt/+Ee/OXhHch5K4+81zP2+QX8Lkc/nJ2QSmCySxOke7TEbmX69fe2g==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.804.0.tgz",
+      "integrity": "sha512-YW1hySBolALMII6C8y7Z0CRG2UX1dGJjLEBNFeefhO/xP7ZuE1dvnmfJGaEuBMnvc3wkRS63VZ3aqX6sevM1CA==",
       "requires": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.22.tgz",
-      "integrity": "sha512-ot1kZ1JGHUxcXPOARhej/n/+Odfx9VPt60pNrUq8Lf/U2blIF3+uj5v56gw76VD70dZvrfeLNo9jKz6pQJfOlA==",
+      "version": "3.974.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.29.tgz",
+      "integrity": "sha512-ALTHDXk6YWVDfAWIHzXyaTZ82QFoMWhHENXlO61lv4ZqSMl3cvh2s0ZVOS89qbtw9LRJhIDoZaaC9FYo/Z4KLQ==",
       "requires": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/crc64-nvme": "^3.972.9",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/checksums": "^3.1000.4",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-          "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-host-header": {
@@ -31054,24 +31890,13 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
-      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.804.0.tgz",
+      "integrity": "sha512-AMtKnllIWKgoo7hiJfphLYotEwTERfjVMO2+cKAncz9w1g+bnYhHxiVhJJoR94y047c06X4PU5MsTxvdQ73Znw==",
       "requires": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-logger": {
@@ -31096,63 +31921,52 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.43.tgz",
-      "integrity": "sha512-CBmixMY36JdAdt9ALgm7yVlvOXGUCHt9Z2kn5p9XVO5StO6HCH+cayV7YYV1CDLsXvVyebaXgBmif9wHoxCeNA==",
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.50.tgz",
+      "integrity": "sha512-yOXn9mmJQQODpbmwQB224IX1PLLneyqInX2Fv2nEmSHWpJj54nrzdrUT1TGQk/s8mr+XPssDQy1at/8GS4EFVQ==",
       "requires": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.29",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.33",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
+          "version": "3.974.20",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+          "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
           "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
+            "@aws-sdk/types": "^3.973.12",
+            "@aws-sdk/xml-builder": "^3.972.29",
             "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
+            "@smithy/core": "^3.24.6",
+            "@smithy/signature-v4": "^5.4.6",
+            "@smithy/types": "^4.14.3",
             "bowser": "^2.11.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
-      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.804.0.tgz",
+      "integrity": "sha512-Tk8jK0gOIUBvEPTz/wwSlP1V70zVQ3QYqsLPAjQRMO6zfOK9ax31dln3MgKvFDJxBydS2tS3wsn53v+brxDxTA==",
       "requires": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
-          "requires": {
-            "@smithy/types": "^4.14.2",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-user-agent": {
@@ -31170,40 +31984,28 @@
       }
     },
     "@aws-sdk/middleware-websocket": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.22.tgz",
-      "integrity": "sha512-aumo6pYnvD1/eda3R0UDkRVecwxsuW4zTZLdjbHg7NqYMKmy7vK0bM3NGJzCD+Ys8iqCC7EeDU4LuWVIsXvL+A==",
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.936.0.tgz",
+      "integrity": "sha512-bPe3rqeugyj/MmjP0yBSZox2v1Wa8Dv39KN+RxVbQroLO8VUitBo6xyZ0oZebhZ5sASwSg58aDcMlX0uFLQnTA==",
       "requires": {
-        "@aws-sdk/core": "^3.974.14",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.3",
-        "@smithy/fetch-http-handler": "^5.4.3",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-format-url": "3.936.0",
+        "@smithy/eventstream-codec": "^4.2.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
-        "@aws-sdk/core": {
-          "version": "3.974.14",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.14.tgz",
-          "integrity": "sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==",
-          "requires": {
-            "@aws-sdk/types": "^3.973.9",
-            "@aws-sdk/xml-builder": "^3.972.26",
-            "@aws/lambda-invoke-store": "^0.2.2",
-            "@smithy/core": "^3.24.3",
-            "@smithy/signature-v4": "^5.4.2",
-            "@smithy/types": "^4.14.2",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+          "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.9.0",
             "tslib": "^2.6.2"
           }
         }
@@ -31417,22 +32219,22 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.29.tgz",
-      "integrity": "sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==",
+      "version": "3.996.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.33.tgz",
+      "integrity": "sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==",
       "requires": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "dependencies": {
         "@aws-sdk/types": {
-          "version": "3.973.9",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-          "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+          "version": "3.973.12",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+          "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
           "requires": {
-            "@smithy/types": "^4.14.2",
+            "@smithy/types": "^4.14.3",
             "tslib": "^2.6.2"
           }
         }
@@ -31479,6 +32281,28 @@
         "tslib": "^2.6.2"
       }
     },
+    "@aws-sdk/util-format-url": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
+      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
+      "requires": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.936.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+          "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+          "requires": {
+            "@smithy/types": "^4.9.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
     "@aws-sdk/util-locate-window": {
       "version": "3.873.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.873.0.tgz",
@@ -31519,11 +32343,11 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "requires": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -31540,9 +32364,12 @@
           }
         },
         "strnum": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-          "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+          "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+          "requires": {
+            "anynum": "^1.0.0"
+          }
         }
       }
     },
@@ -31552,9 +32379,9 @@
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
     },
     "@azure-rest/core-client": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
-      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.1.tgz",
+      "integrity": "sha512-KzI10qnkWTsVS2yRBUdc8NLUJ1rOm+292mYs7Pe9wqAj/jv4bRskVm1l8XkKeVTN0OCQtrU5RG0Yhjbz1Wmg7g==",
       "requires": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.10.0",
@@ -31749,9 +32576,12 @@
           }
         },
         "strnum": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-          "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+          "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+          "requires": {
+            "anynum": "^1.0.0"
+          }
         }
       }
     },
@@ -31820,20 +32650,19 @@
       }
     },
     "@azure/keyvault-keys": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.0.tgz",
-      "integrity": "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.2.tgz",
+      "integrity": "sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==",
       "requires": {
         "@azure-rest/core-client": "^2.3.3",
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
         "@azure/core-lro": "^2.7.2",
         "@azure/core-paging": "^1.6.2",
         "@azure/core-rest-pipeline": "^1.19.0",
         "@azure/core-tracing": "^1.2.0",
         "@azure/core-util": "^1.11.0",
-        "@azure/keyvault-common": "^2.0.0",
+        "@azure/keyvault-common": "^2.1.0",
         "@azure/logger": "^1.1.4",
         "tslib": "^2.8.1"
       },
@@ -31988,9 +32817,9 @@
       "peer": true
     },
     "@browserbasehq/sdk": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.12.0.tgz",
-      "integrity": "sha512-bwgVjjYc4O54Cvkc5POfZUv0Gl92n1nNfAPueRLQVFsDoPRTw0FS8wKo9/bQCQuyzAg9+RQUDqvUC241ogLRTQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.14.0.tgz",
+      "integrity": "sha512-DqVfjlgt74vPWfWiCp4VPtiMNJxg2yBZwio2uOfnpV1aJM0OWZR4AJrt/4df+xgQQ/guRpds5do41ycrDaYt3w==",
       "peer": true,
       "requires": {
         "@types/node": "^18.11.18",
@@ -32165,26 +32994,6 @@
         }
       }
     },
-    "@dsnp/parquetjs": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@dsnp/parquetjs/-/parquetjs-1.8.7.tgz",
-      "integrity": "sha512-3DkkN3FKJ++BQy8PE3LONoVSVBONG7hld9D+VqBp1Dcfw2PGSnWyg20NET5cJkiygWK2y2H1ra8GWk3yixzuuA==",
-      "requires": {
-        "@aws-sdk/client-s3": "^3.750.0",
-        "@types/node-int64": "^0.4.32",
-        "@types/thrift": "^0.10.17",
-        "@zenfs/core": "^1.11.2",
-        "brotli-wasm": "^3.0.1",
-        "bson": "6.10.3",
-        "int53": "^1.0.0",
-        "long": "^5.3.1",
-        "node-int64": "^0.4.0",
-        "snappyjs": "^0.7.0",
-        "thrift": "0.21.0",
-        "varint": "^6.0.0",
-        "xxhash-wasm": "^1.1.0"
-      }
-    },
     "@ewoudenberg/difflib": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@ewoudenberg/difflib/-/difflib-0.1.0.tgz",
@@ -32252,9 +33061,9 @@
       }
     },
     "@google-cloud/storage": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
-      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
       "requires": {
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
@@ -32269,8 +33078,7 @@
         "mime": "^3.0.0",
         "p-limit": "^3.0.1",
         "retry-request": "^7.0.0",
-        "teeny-request": "^9.0.0",
-        "uuid": "^8.0.0"
+        "teeny-request": "^9.0.0"
       },
       "dependencies": {
         "fast-xml-parser": {
@@ -32286,14 +33094,12 @@
           }
         },
         "strnum": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-          "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+          "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+          "requires": {
+            "anynum": "^1.0.0"
+          }
         }
       }
     },
@@ -32381,9 +33187,9 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@ibm-cloud/watsonx-ai": {
-      "version": "1.7.12",
-      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.12.tgz",
-      "integrity": "sha512-++tkoj1yLKNMeS+EPC/cvVYQZbyLAUGdDy/QeUObhRYSQmENDnCcA3Y1qquBH6XcPLXw7sQCQZCwFfhCTrvJow==",
+      "version": "1.7.13",
+      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.13.tgz",
+      "integrity": "sha512-xduIj2subUermAwmz3mz5LXlLfUVyN+NwzswsIkl5EmU4t4VJ/040gtdbsjmwWrwKBA6xPxTt3i1NAEaFVvahA==",
       "peer": true,
       "requires": {
         "form-data": "^4.0.4",
@@ -32585,13 +33391,6 @@
       "requires": {
         "@anthropic-ai/sdk": "^0.90.0",
         "zod": "^3.25.76 || ^4"
-      },
-      "dependencies": {
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
-        }
       }
     },
     "@langchain/aws": {
@@ -32632,21 +33431,10 @@
             "zod": "^3.25.76 || ^4"
           }
         },
-        "openai": {
-          "version": "6.39.0",
-          "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-          "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
-          "requires": {}
-        },
         "uuid": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
           "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
-        },
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
         }
       }
     },
@@ -32678,13 +33466,6 @@
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "zod": "^3.25.76 || ^4"
-      },
-      "dependencies": {
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
-        }
       }
     },
     "@langchain/google-common": {
@@ -32712,9 +33493,9 @@
       },
       "dependencies": {
         "gaxios": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-          "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+          "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
           "requires": {
             "extend": "^3.0.2",
             "https-proxy-agent": "^7.0.1",
@@ -32732,9 +33513,9 @@
           }
         },
         "google-auth-library": {
-          "version": "10.6.2",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-          "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+          "version": "10.7.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+          "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
           "requires": {
             "base64-js": "^1.3.0",
             "ecdsa-sig-formatter": "^1.0.11",
@@ -32806,17 +33587,17 @@
       }
     },
     "@langchain/langgraph-checkpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.4.tgz",
+      "integrity": "sha512-1y5MgZ0gXXrtmoy56e3kaBChI3GwFPIKl27xkrHwN+VE/3iUsyr9gO3Jtp7kdKAe6diZGbcas5bdC/r0yUwTZA==",
       "requires": {
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "dependencies": {
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+          "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="
         }
       }
     },
@@ -32839,13 +33620,6 @@
         "debug": "^4.4.3",
         "extended-eventsource": "^1.7.0",
         "zod": "^3.25.76 || ^4"
-      },
-      "dependencies": {
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
-        }
       }
     },
     "@langchain/mistralai": {
@@ -32896,19 +33670,6 @@
         "js-tiktoken": "^1.0.12",
         "openai": "^6.32.0",
         "zod": "^3.25.76 || ^4"
-      },
-      "dependencies": {
-        "openai": {
-          "version": "6.39.0",
-          "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-          "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
-          "requires": {}
-        },
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
-        }
       }
     },
     "@langchain/pinecone": {
@@ -32928,9 +33689,9 @@
       }
     },
     "@langchain/protocol": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ=="
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
+      "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg=="
     },
     "@langchain/qdrant": {
       "version": "1.0.1",
@@ -33865,14 +34626,6 @@
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.24.1"
-      },
-      "dependencies": {
-        "zod-to-json-schema": {
-          "version": "3.25.2",
-          "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-          "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-          "requires": {}
-        }
       }
     },
     "@mixmark-io/domino": {
@@ -33964,12 +34717,6 @@
           "requires": {
             "mime-db": "^1.54.0"
           }
-        },
-        "zod-to-json-schema": {
-          "version": "3.25.2",
-          "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-          "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-          "requires": {}
         }
       }
     },
@@ -34038,60 +34785,81 @@
         "undici": "^7.16.0"
       }
     },
-    "@n8n/agents": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/agents/-/agents-0.9.0.tgz",
-      "integrity": "sha512-drLfuL43lBtiltgVad2bFCt8cngG34BmzDZnoOxaqU0OCfT4CVlk0Dzkg0TfMTALL9CCWLUJV5P9rnXaSUMwng==",
+    "@n8n_io/riot-tmpl": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
+      "integrity": "sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==",
+      "peer": true,
       "requires": {
-        "@ai-sdk/amazon-bedrock": "^4.0.95",
-        "@ai-sdk/anthropic": "3.0.58",
-        "@ai-sdk/azure": "^3.0.54",
-        "@ai-sdk/cohere": "^3.0.30",
-        "@ai-sdk/deepseek": "^2.0.29",
-        "@ai-sdk/gateway": "^3.0.104",
-        "@ai-sdk/google": "^3.0.43",
-        "@ai-sdk/groq": "^3.0.35",
-        "@ai-sdk/mistral": "^3.0.30",
-        "@ai-sdk/openai": "^3.0.41",
-        "@ai-sdk/provider-utils": "^4.0.21",
-        "@ai-sdk/xai": "^3.0.67",
+        "eslint-config-riot": "^1.0.0"
+      }
+    },
+    "@n8n/agents": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@n8n/agents/-/agents-0.11.0.tgz",
+      "integrity": "sha512-uJ1r0w3OrcL7ZU9x54oNXfG0otQJ4Vx/5dQNT24+TCBsIZ2Fil1QKhzB6bGHzbk7tmoo3gWRpKhyp8DLLzrl2A==",
+      "requires": {
+        "@ai-sdk/amazon-bedrock": "^4.0.113",
+        "@ai-sdk/anthropic": "^3.0.81",
+        "@ai-sdk/azure": "^3.0.70",
+        "@ai-sdk/cohere": "^3.0.36",
+        "@ai-sdk/deepseek": "^2.0.35",
+        "@ai-sdk/gateway": "^3.0.125",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/groq": "^3.0.39",
+        "@ai-sdk/mistral": "^3.0.37",
+        "@ai-sdk/openai": "^3.0.68",
+        "@ai-sdk/openai-compatible": "^2.0.48",
+        "@ai-sdk/provider-utils": "^4.0.27",
+        "@ai-sdk/xai": "^3.0.93",
+        "@daytonaio/sdk": "0.175.0",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@n8n/ai-utilities": "0.17.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/sandbox-client": "0.0.4",
+        "@n8n/utils": "1.34.0",
         "@openrouter/ai-sdk-provider": "^2.8.0",
-        "ai": "^6.0.116",
+        "ai": "^6.0.197",
         "ajv": "^8.18.0",
         "yaml": "2.8.3",
         "zod": "3.25.67"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        }
       }
     },
     "@n8n/ai-node-sdk": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.14.0.tgz",
-      "integrity": "sha512-QGaagbU3KzZIDngcjTxV6Ei1nQeVx7oMqTH1LhLlPJvxX0sWFRpavMRNGbSofmZoiFnXMHvLtgyc8n6I6P137w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.16.0.tgz",
+      "integrity": "sha512-2Xf8yTRw53ec1tN9kuclU/9svArl8jUGIOmg8hVmpOOeeLkkDXkpjBBoQcsKn5UpB0BQHcQIqKvi7CBgYbEj5Q==",
       "requires": {
-        "@n8n/ai-utilities": "0.17.0"
+        "@n8n/ai-utilities": "0.19.0"
       }
     },
     "@n8n/ai-utilities": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.17.0.tgz",
-      "integrity": "sha512-MnCBMvXxHX9GtdjheqaO9DPGIbC5xTdyLSMMWfYLXK2xldUHZqcmeRHeAYnlg2rn9VkKFOqsn7T+h1ljF12KvA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.19.0.tgz",
+      "integrity": "sha512-XQpPUUtX+GqwYWa83xUmQkhsCYT3rRRlD2BcfviwSPDuVHnzU3iGcEVN2CPhAXFVorzVN/EDuOiKBGcTc0kmbA==",
       "requires": {
         "@langchain/classic": "1.0.27",
         "@langchain/community": "1.1.27",
         "@langchain/core": "1.1.41",
         "@langchain/openai": "1.4.4",
         "@langchain/textsplitters": "1.0.1",
-        "@n8n/config": "2.22.0",
-        "@n8n/typescript-config": "1.4.0",
-        "@n8n/utils": "1.32.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/typescript-config": "1.5.0",
+        "@n8n/utils": "1.34.0",
+        "@thednp/dommatrix": "^2.0.12",
         "https-proxy-agent": "7.0.6",
         "js-tiktoken": "1.0.21",
         "langchain": "1.2.30",
         "pdf-parse": "2.4.5",
         "proxy-from-env": "^1.1.0",
         "tmp-promise": "3.0.3",
-        "undici": "^6.21.0",
+        "undici": "^6.24.0",
         "zod": "3.25.67",
         "zod-to-json-schema": "3.23.3"
       },
@@ -34159,9 +34927,9 @@
               },
               "dependencies": {
                 "openai": {
-                  "version": "6.39.0",
-                  "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-                  "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
+                  "version": "6.42.0",
+                  "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+                  "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
                   "requires": {}
                 }
               }
@@ -34230,6 +34998,21 @@
             "web-streams-polyfill": "4.0.0-beta.3"
           }
         },
+        "openai": {
+          "version": "4.104.0",
+          "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+          "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+          "peer": true,
+          "requires": {
+            "@types/node": "^18.11.18",
+            "@types/node-fetch": "^2.6.4",
+            "abort-controller": "^3.0.0",
+            "agentkeepalive": "^4.2.1",
+            "form-data-encoder": "1.7.2",
+            "formdata-node": "^4.3.2",
+            "node-fetch": "^2.6.7"
+          }
+        },
         "undici": {
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
@@ -34245,13 +35028,24 @@
           "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
           "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
           "peer": true
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        },
+        "zod-to-json-schema": {
+          "version": "3.23.3",
+          "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+          "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+          "requires": {}
         }
       }
     },
     "@n8n/ai-workflow-builder": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-1.23.0.tgz",
-      "integrity": "sha512-OwZz7AMStDS1sP5HV01cAJTiDDKl2ogpZNsU4CwqSUDGRbzqD5pWqPgxZ14Fo1IP+Q81P0W9bK4r2wwZ1dp0Rg==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-1.26.1.tgz",
+      "integrity": "sha512-B7DE1SgCwP+U7500FeZDsf/Yy3VjKCjfNnjdZ1qlx4mH8U/+VxZOIQ1FpzC8L1rFKzfLGy8+Fa2ONOlmBii5vg==",
       "requires": {
         "@langchain/anthropic": "1.3.27",
         "@langchain/core": "1.1.41",
@@ -34259,19 +35053,20 @@
         "@langchain/openai": "1.4.4",
         "@mozilla/readability": "0.6.0",
         "@n8n_io/ai-assistant-sdk": "1.21.0",
-        "@n8n/ai-utilities": "0.17.0",
-        "@n8n/api-types": "1.23.0",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/utils": "1.32.0",
-        "@n8n/workflow-sdk": "0.16.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/utils": "1.34.0",
+        "@n8n/workflow-sdk": "0.19.1",
+        "axios": "1.16.1",
         "csv-parse": "6.2.1",
         "jsdom": "23.0.1",
         "langchain": "1.2.30",
         "langsmith": "^0.4.6",
         "lodash": "4.18.1",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "picocolors": "1.0.1",
         "turndown": "^7.2.2",
         "zod": "3.25.67"
@@ -34296,9 +35091,9 @@
           },
           "dependencies": {
             "langsmith": {
-              "version": "0.7.2",
-              "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.2.tgz",
-              "integrity": "sha512-3dZUwQDJluxi2ih5eIygFODtlrQKrs3Tua0Ck3l+DAUkSGFkB1Dc0JPqkGbqiVSN+TQDElnkev/ydAOAz6jndA==",
+              "version": "0.7.6",
+              "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.6.tgz",
+              "integrity": "sha512-6IRm+sAxHT2n5GAZbqEnUzkhOu3Q8vqQtMiOpYfGiI+pxUe/fYQSzV0Pr7q5x9JD8bnZ8xK2/P9dhPHs4zO/Nw==",
               "requires": {
                 "p-queue": "6.6.2"
               }
@@ -34310,6 +35105,16 @@
             }
           }
         },
+        "@n8n/api-types": {
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+          "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+          "requires": {
+            "@n8n/permissions": "0.63.0",
+            "n8n-workflow": "2.26.1",
+            "xss": "1.0.15"
+          }
+        },
         "@types/uuid": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -34319,6 +35124,18 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
         },
         "langsmith": {
           "version": "0.4.12",
@@ -34340,148 +35157,663 @@
             }
           }
         },
-        "semver": {
-          "version": "7.8.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-          "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
         },
         "uuid": {
           "version": "11.1.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
           "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
         }
       }
     },
-    "@n8n/api-types": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.23.0.tgz",
-      "integrity": "sha512-m1jTiZ4WAEeY3lQCLjzFBj7sN1PHYlY9Ax68sg113YQHekzeTrk6l1GQwqxeJVpX+DiyXg6sROvi4klpvI+baA==",
-      "requires": {
-        "@n8n/permissions": "0.61.0",
-        "n8n-workflow": "2.23.0",
-        "xss": "1.0.15"
-      }
-    },
     "@n8n/backend-common": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.23.0.tgz",
-      "integrity": "sha512-1qqvc8AH/SdN3RE3a23l1VIrSH8PtR2LPasI3VcobjQrZz5Ak8GbZhxVbSM+oCdx68YdoCSWFsMzN6N6OWq8pg==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.26.1.tgz",
+      "integrity": "sha512-imE00ovHfy9sYQrxLy/9cCj4wjiLDBKbL4Bit5bGKWT+mnDKIIB22Q+wiZDthIpYfIGCciignYzlvJyEuj8kWQ==",
       "requires": {
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
         "callsites": "3.1.0",
         "flatted": "3.4.2",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "picocolors": "1.0.1",
         "reflect-metadata": "0.2.2",
         "stream-json": "1.9.1",
         "winston": "3.14.2",
         "yargs-parser": "21.1.1"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+          "peer": true
+        }
       }
     },
     "@n8n/chat-hub": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/chat-hub/-/chat-hub-1.16.0.tgz",
-      "integrity": "sha512-s11MDWPbWke17tkQS11GxNT18S6NY8h5AY4HzVxImtmRw+I8QyiENRw1d9S1KxdS+r7DhQjAAPgySm6joIHpDQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@n8n/chat-hub/-/chat-hub-1.19.1.tgz",
+      "integrity": "sha512-g8DNjan1zu8lJlLVMElzYPaG8tab/ZXuxVe99BpZZhQaQnj13k02B7Up/0Ft/7Jtc5CJhps6KvnlDf2nmTm28Q==",
       "requires": {
-        "@n8n/api-types": "1.23.0"
+        "@n8n/api-types": "1.26.1"
+      },
+      "dependencies": {
+        "@n8n/api-types": {
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+          "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+          "requires": {
+            "@n8n/permissions": "0.63.0",
+            "n8n-workflow": "2.26.1",
+            "xss": "1.0.15"
+          }
+        },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+          "peer": true
+        }
       }
     },
     "@n8n/client-oauth2": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@n8n/client-oauth2/-/client-oauth2-1.7.0.tgz",
-      "integrity": "sha512-YOWL5mh6T5Ak6ohLE67JfyhF5RZZFQlSoMNHAkgpfqSqcyDha/xztz5czXFWOoiXku0yeru1wNwIEx/tqcqD7Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@n8n/client-oauth2/-/client-oauth2-1.8.0.tgz",
+      "integrity": "sha512-Ol5Cx1nr1BLUmqp+6TMgfh+/d7sQORcZnuPnOmTtZOsNCTQWy5DQIRBnCjJQouDwbcRmjlyoej4W4a/dHr/K/w==",
       "requires": {
         "axios": "1.16.1"
       }
     },
     "@n8n/config": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.22.0.tgz",
-      "integrity": "sha512-vVO8Xj+aY4vqrC6lAvdHt3KqIwDXMTUG79jxZygdB/smUfB9TkxPyi5KGfTuVGo0tdB2wNQKx4lmgc10squHRg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.24.0.tgz",
+      "integrity": "sha512-UNNJQNnyCo6FfdqtP5JbkZ8ztOexuq4JseiznIRR8H45E/pm0aP2HftXJM8IHVpcQeKRv1XpbRZSlFdZd3pwbw==",
       "requires": {
-        "@n8n/di": "0.12.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/di": "0.13.0",
         "reflect-metadata": "0.2.2",
         "zod": "3.25.67"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        }
       }
     },
     "@n8n/constants": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.25.0.tgz",
-      "integrity": "sha512-l82Iwp8y/KEzuQeW2IeUhwroKM4Cbt0IkFRBwd2fZvHbEyFySnfB+KGULowFQLWtgbnscJRj1YJIlBw8gRSDuw=="
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.26.0.tgz",
+      "integrity": "sha512-25BYGmGBD6zmbrbwJys0bHzmSiEth374kmzii3HC8jVfx0Lyms+vh1rzjAnvcvcY/zkJ8ic3fDvewvpzasb6AQ=="
     },
     "@n8n/db": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-1.23.0.tgz",
-      "integrity": "sha512-eULIs9XUDjd1bqzhsKHP51H6dAmmJysIBappnBzEcK655dhjpYB+OSR+AML56iVC2WZJrZMCUrhaH+y2b5bMRg==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-1.26.1.tgz",
+      "integrity": "sha512-/u1qzA+xsR2UAwMGnYDb1XMdeK56OzgwHnDgVAN9UiPJDjPsXhQvMGipoJit48E+bQrB+wUZGNaU3iJZ0+0slg==",
       "requires": {
-        "@n8n/api-types": "1.23.0",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/permissions": "0.61.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/permissions": "0.63.0",
         "@n8n/typeorm": "0.3.20-17",
-        "@n8n/utils": "1.32.0",
+        "@n8n/utils": "1.34.0",
         "class-validator": "0.14.0",
         "flatted": "3.4.2",
         "lodash": "4.18.1",
-        "n8n-core": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-core": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "p-lazy": "3.1.0",
         "reflect-metadata": "0.2.2",
-        "uuid": "10.0.0",
+        "uuid": "11.1.1",
         "xss": "1.0.15",
         "zod": "3.25.67"
       },
       "dependencies": {
+        "@aws-sdk/client-s3": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.808.0.tgz",
+          "integrity": "sha512-8RY3Jsm84twmYfiqnMkxznuY6pBX7y2GiuEJVdW1ZJLXRDOiCPkTBHsO6jUwppfMua7HRhO2OTAdWr7aSBAdPw==",
+          "requires": {
+            "@aws-crypto/sha1-browser": "5.2.0",
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.808.0",
+            "@aws-sdk/credential-provider-node": "3.808.0",
+            "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+            "@aws-sdk/middleware-expect-continue": "3.804.0",
+            "@aws-sdk/middleware-flexible-checksums": "3.808.0",
+            "@aws-sdk/middleware-host-header": "3.804.0",
+            "@aws-sdk/middleware-location-constraint": "3.804.0",
+            "@aws-sdk/middleware-logger": "3.804.0",
+            "@aws-sdk/middleware-recursion-detection": "3.804.0",
+            "@aws-sdk/middleware-sdk-s3": "3.808.0",
+            "@aws-sdk/middleware-ssec": "3.804.0",
+            "@aws-sdk/middleware-user-agent": "3.808.0",
+            "@aws-sdk/region-config-resolver": "3.808.0",
+            "@aws-sdk/signature-v4-multi-region": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@aws-sdk/util-endpoints": "3.808.0",
+            "@aws-sdk/util-user-agent-browser": "3.804.0",
+            "@aws-sdk/util-user-agent-node": "3.808.0",
+            "@aws-sdk/xml-builder": "3.804.0",
+            "@smithy/config-resolver": "^4.1.2",
+            "@smithy/core": "^3.3.1",
+            "@smithy/eventstream-serde-browser": "^4.0.2",
+            "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+            "@smithy/eventstream-serde-node": "^4.0.2",
+            "@smithy/fetch-http-handler": "^5.0.2",
+            "@smithy/hash-blob-browser": "^4.0.2",
+            "@smithy/hash-node": "^4.0.2",
+            "@smithy/hash-stream-node": "^4.0.2",
+            "@smithy/invalid-dependency": "^4.0.2",
+            "@smithy/md5-js": "^4.0.2",
+            "@smithy/middleware-content-length": "^4.0.2",
+            "@smithy/middleware-endpoint": "^4.1.4",
+            "@smithy/middleware-retry": "^4.1.5",
+            "@smithy/middleware-serde": "^4.0.3",
+            "@smithy/middleware-stack": "^4.0.2",
+            "@smithy/node-config-provider": "^4.1.1",
+            "@smithy/node-http-handler": "^4.0.4",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/smithy-client": "^4.2.4",
+            "@smithy/types": "^4.2.0",
+            "@smithy/url-parser": "^4.0.2",
+            "@smithy/util-base64": "^4.0.0",
+            "@smithy/util-body-length-browser": "^4.0.0",
+            "@smithy/util-body-length-node": "^4.0.0",
+            "@smithy/util-defaults-mode-browser": "^4.0.12",
+            "@smithy/util-defaults-mode-node": "^4.0.12",
+            "@smithy/util-endpoints": "^3.0.4",
+            "@smithy/util-middleware": "^4.0.2",
+            "@smithy/util-retry": "^4.0.3",
+            "@smithy/util-stream": "^4.2.0",
+            "@smithy/util-utf8": "^4.0.0",
+            "@smithy/util-waiter": "^4.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-flexible-checksums": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
+          "integrity": "sha512-NW1yoTYDH2h8ycqMPNkvW3d1XT2vEeXfXclagL2tv82P7Qt7vPXYcObs/YtETvNZ7hdnmOftJ/IJv7YrFC8vtQ==",
+          "requires": {
+            "@aws-crypto/crc32": "5.2.0",
+            "@aws-crypto/crc32c": "5.2.0",
+            "@aws-crypto/util": "5.2.0",
+            "@aws-sdk/core": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@smithy/is-array-buffer": "^4.0.0",
+            "@smithy/node-config-provider": "^4.1.1",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/types": "^4.2.0",
+            "@smithy/util-middleware": "^4.0.2",
+            "@smithy/util-stream": "^4.2.0",
+            "@smithy/util-utf8": "^4.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-s3": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.808.0.tgz",
+          "integrity": "sha512-qvyJTDf0HIsPpZzBUqhNQm5g8stAn2EOwVsaAolsOHuBsdaBAE/s/NgPzazDlSXwdF0ITvsIouUVDCn4fJGJqQ==",
+          "requires": {
+            "@aws-sdk/core": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@aws-sdk/util-arn-parser": "3.804.0",
+            "@smithy/core": "^3.3.1",
+            "@smithy/node-config-provider": "^4.1.1",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/signature-v4": "^5.1.0",
+            "@smithy/smithy-client": "^4.2.4",
+            "@smithy/types": "^4.2.0",
+            "@smithy/util-config-provider": "^4.0.0",
+            "@smithy/util-middleware": "^4.0.2",
+            "@smithy/util-stream": "^4.2.0",
+            "@smithy/util-utf8": "^4.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/signature-v4-multi-region": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.808.0.tgz",
+          "integrity": "sha512-lQuEB6JK81eKV7fdiktmRq06Y1KCcJbx9fLf7b19nSfYUbJSn/kfSpHPv/tOkJK2HKnN61JsfG19YU8k4SOU8Q==",
+          "requires": {
+            "@aws-sdk/middleware-sdk-s3": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/signature-v4": "^5.1.0",
+            "@smithy/types": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/xml-builder": {
+          "version": "3.804.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
+          "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
+          "requires": {
+            "@smithy/types": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@langchain/core": {
+          "version": "1.1.41",
+          "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+          "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+          "requires": {
+            "@cfworker/json-schema": "^4.0.2",
+            "@standard-schema/spec": "^1.1.0",
+            "ansi-styles": "^5.0.0",
+            "camelcase": "6",
+            "decamelize": "1.2.0",
+            "js-tiktoken": "^1.0.12",
+            "langsmith": ">=0.5.0 <1.0.0",
+            "mustache": "^4.2.0",
+            "p-queue": "^6.6.2",
+            "uuid": "^11.1.0",
+            "zod": "^3.25.76 || ^4"
+          },
+          "dependencies": {
+            "zod": {
+              "version": "4.4.3",
+              "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+              "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+            }
+          }
+        },
+        "@n8n/api-types": {
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+          "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+          "requires": {
+            "@n8n/permissions": "0.63.0",
+            "n8n-workflow": "2.26.1",
+            "xss": "1.0.15"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        },
+        "file-type": {
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+          "requires": {
+            "readable-web-to-node-stream": "^3.0.0",
+            "strtok3": "^6.2.4",
+            "token-types": "^4.1.1"
+          }
+        },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "n8n-core": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.26.1.tgz",
+          "integrity": "sha512-X0IO6e89aGVA3PUPz0YhE/CwHoipeHaGBVlFs0FHEq+DZq5D21HQkbHT89+OBQLM58Vd5fGE0ceITgeeaSbhPA==",
+          "requires": {
+            "@aws-sdk/client-s3": "3.808.0",
+            "@langchain/core": "1.1.41",
+            "@n8n/backend-common": "1.26.1",
+            "@n8n/client-oauth2": "1.8.0",
+            "@n8n/config": "2.24.0",
+            "@n8n/constants": "0.26.0",
+            "@n8n/decorators": "1.26.1",
+            "@n8n/di": "0.13.0",
+            "@n8n/workflow-sdk": "0.19.1",
+            "@sentry/node": "^10.55.0",
+            "@sentry/node-native": "^10.55.0",
+            "@sentry/profiling-node": "^10.55.0",
+            "axios": "1.16.1",
+            "cache-manager": "5.2.3",
+            "callsites": "3.1.0",
+            "chardet": "2.0.0",
+            "cron": "4.4.0",
+            "fast-glob": "3.2.12",
+            "file-type": "16.5.4",
+            "form-data": "4.0.4",
+            "htmlparser2": "^10.0.0",
+            "http-proxy-agent": "7.0.2",
+            "https-proxy-agent": "7.0.6",
+            "iconv-lite": "0.6.3",
+            "jsonwebtoken": "9.0.3",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "mime-types": "3.0.2",
+            "n8n-workflow": "2.26.1",
+            "nanoid": "3.3.8",
+            "oauth-1.0a": "2.2.6",
+            "p-cancelable": "2.1.1",
+            "picocolors": "1.0.1",
+            "pretty-bytes": "5.6.0",
+            "proxy-from-env": "^1.1.0",
+            "qs": "6.14.2",
+            "ssh2": "1.15.0",
+            "uuid": "11.1.1",
+            "winston": "3.14.2",
+            "xml2js": "0.6.2"
+          },
+          "dependencies": {
+            "mime-types": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+              "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+              "requires": {
+                "mime-db": "^1.54.0"
+              }
+            }
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "ssh2": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+          "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+          "requires": {
+            "asn1": "^0.2.6",
+            "bcrypt-pbkdf": "^1.0.2",
+            "cpu-features": "~0.0.9",
+            "nan": "^2.18.0"
+          }
+        },
+        "strtok3": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+          "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+          "requires": {
+            "@tokenizer/token": "^0.3.0",
+            "peek-readable": "^4.1.0"
+          }
+        },
+        "token-types": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+          "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+          "requires": {
+            "@tokenizer/token": "^0.3.0",
+            "ieee754": "^1.2.1"
+          }
+        },
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
         }
       }
     },
     "@n8n/decorators": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.23.0.tgz",
-      "integrity": "sha512-epGFm2+YXvt7K55tRihknZ6Ot53v096n8dCN6UMHxpDPPo2dwhY9Vd2Lq+a7thDiIa9qmrHScb3IoI7dkVB4IA==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.26.1.tgz",
+      "integrity": "sha512-9n+kBAgk+yX2Yn/cRWoqOYNomehKU4N3nFwgYHQ+J4eEj+hPXlYmgY1XzZB5UxDTkWFZfxzOZA5Mupp4r8QwqA==",
       "requires": {
-        "@n8n/api-types": "1.23.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/permissions": "0.61.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/constants": "0.26.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/permissions": "0.63.0",
         "lodash": "4.18.1",
-        "n8n-workflow": "2.23.0"
+        "n8n-workflow": "2.26.1"
+      },
+      "dependencies": {
+        "@n8n/api-types": {
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+          "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+          "requires": {
+            "@n8n/permissions": "0.63.0",
+            "n8n-workflow": "2.26.1",
+            "xss": "1.0.15"
+          }
+        },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+          "peer": true
+        }
       }
     },
     "@n8n/di": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.12.0.tgz",
-      "integrity": "sha512-qZWcViQhOAIHewhAqaGkQ/ixAiK0Ki3FQ45Xwh+pkPoL587HOKZjlMSETnTssANL7IQvAtu+Cf/ug2XnTkYXTg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.13.0.tgz",
+      "integrity": "sha512-pxsmn2UqcSnMQwb2zSSZcZZMViiOUnJVrRLoDZPhUZVbdAhmttQJGtm82+6hWPEc4wAOAMFbO1U3X53Wu29Y2g==",
       "requires": {
         "reflect-metadata": "0.2.2"
       }
     },
     "@n8n/errors": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.8.0.tgz",
-      "integrity": "sha512-aAYL79o/bio21zxzXCGwqnvhPcEsK+HqKNz5DsPGY0tMo6FEFT2mowtxcYRoRbHbx9siraJVhiu+VN+Ya7Iv0g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.9.0.tgz",
+      "integrity": "sha512-FDSpOMLD4SKZ3GlZXJXwCvszqd1ze7HaJMmGyubSB+67BKmUfV5k4oSAdbdzXWC4ughObh0JA8epOWKxnj2u1A==",
       "requires": {
         "callsites": "3.1.0"
       }
     },
     "@n8n/expression-runtime": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.15.0.tgz",
-      "integrity": "sha512-0MlWU8p+QYGS+KVXx+mBx1rKvFfx9DUXGotDgFwwQOlBFa+Q6Ah1sWMH1655eGKn+zC9bhZfHyssndeNEPWJdA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.17.0.tgz",
+      "integrity": "sha512-/TLh83BjBr0cSRsXZhjxQ4xN5Ssmoxn33ydhn2gKjWN8RMtINnAPHT8UsGMB85nK8BV+bCZOQsMxq4auuTving==",
       "requires": {
-        "@n8n/errors": "0.8.0",
-        "@n8n/tournament": "1.2.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/tournament": "1.3.0",
         "isolated-vm": "^6.1.2",
         "jmespath": "0.16.0",
         "js-base64": "3.7.8",
@@ -34492,12 +35824,19 @@
         "title-case": "3.0.3",
         "transliteration": "2.3.5",
         "zod": "3.25.67"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        }
       }
     },
     "@n8n/imap": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@n8n/imap/-/imap-0.20.0.tgz",
-      "integrity": "sha512-I53KJ2gfm518AGNpv1y/0k5URkw7cEqoTXYNfOSKlCHlmDrWP8UH6Ta3wVwjBWYHhA79JSLbct4Ifdyjd0knDQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@n8n/imap/-/imap-0.21.0.tgz",
+      "integrity": "sha512-3QSSo9zkBuUk8nV3mbZOJLjXThv7c6hxPGZlTcTJT/QcT9H2yZpEDE+TthEPc2nh2qGk7aWIEgp4tfZQ2EvWOA==",
       "requires": {
         "iconv-lite": "0.6.3",
         "imap": "0.8.19",
@@ -34516,20 +35855,20 @@
       }
     },
     "@n8n/instance-ai": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@n8n/instance-ai/-/instance-ai-1.8.0.tgz",
-      "integrity": "sha512-7sD3kxN58iDFb9cvWj+KKzYF+gU08bSUIK8TFyN6a+rMUOwM6+7UdjHWKVqF8g4ckgg4Bp2SlVUU/nSOUiMmVg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@n8n/instance-ai/-/instance-ai-1.11.1.tgz",
+      "integrity": "sha512-89Ntij3U6rC0x/9vCfwl9H1+WX35GxD4zk1g/SGVP8cI9oG3YJ/8x+vqon4bTcRmRGZM2WVDg+1iZBholSWpGw==",
       "requires": {
         "@daytonaio/sdk": "0.175.0",
         "@joplin/turndown-plugin-gfm": "^1.0.12",
         "@mozilla/readability": "^0.6.0",
-        "@n8n/agents": "0.9.0",
-        "@n8n/api-types": "1.23.0",
-        "@n8n/mcp-browser": "0.7.0",
-        "@n8n/sandbox-client": "0.0.4",
-        "@n8n/utils": "1.32.0",
-        "@n8n/workflow-sdk": "0.16.0",
+        "@n8n/agents": "0.11.0",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/mcp-browser": "0.9.1",
+        "@n8n/utils": "1.34.0",
+        "@n8n/workflow-sdk": "0.19.1",
         "@opentelemetry/api": "^1.9.0",
+        "@thednp/dommatrix": "^2.0.12",
         "csv-parse": "6.2.1",
         "fast-glob": "3.2.12",
         "flatted": "3.4.2",
@@ -34537,7 +35876,7 @@
         "linkedom": "^0.18.9",
         "luxon": "3.7.2",
         "mammoth": "1.12.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "p-limit": "^3.1.0",
         "pdf-parse": "2.4.5",
@@ -34546,18 +35885,80 @@
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "zod": "3.25.67",
         "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5"
+      },
+      "dependencies": {
+        "@n8n/api-types": {
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+          "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+          "requires": {
+            "@n8n/permissions": "0.63.0",
+            "n8n-workflow": "2.26.1",
+            "xss": "1.0.15"
+          }
+        },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        }
       }
     },
-    "@n8n/json-schema-to-zod": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/json-schema-to-zod/-/json-schema-to-zod-1.9.0.tgz",
-      "integrity": "sha512-xOSQHkmz/9xmYXzMb6MRxydpYrAzHdDAfrmLQjtdEyLT51WA/wLbc7LMx04X85qlsfUZfxX4OtEeJFv08mAqow==",
-      "requires": {}
+    "@n8n/mcp-apps": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@n8n/mcp-apps/-/mcp-apps-0.3.0.tgz",
+      "integrity": "sha512-68ZCp2HU0sifOzvIQMbgQzomf3rQ2l9t+E5+kYr1F/RZ6s6N+7y1Mq6w675zVNw7h3j5ZMo1KkWTWq+DIdhPSQ==",
+      "requires": {
+        "@n8n/utils": "1.34.0"
+      }
     },
     "@n8n/mcp-browser": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@n8n/mcp-browser/-/mcp-browser-0.7.0.tgz",
-      "integrity": "sha512-QusktnXWkIMjKB1Ru/s6UbMdThso1g22DuqWgYlDJkmcFCRSeUTzUwEUyoFacUTl0a3+AYpP17Aw+incgIS/gA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@n8n/mcp-browser/-/mcp-browser-0.9.1.tgz",
+      "integrity": "sha512-D09RsiLVHJ+GCqCu/AHBahto7afjl5SUBr1rJkr7duFud/aXg+tfd54cdzImktfm0geJfgNk4krJGYT/o/7n8g==",
       "requires": {
         "@joplin/turndown-plugin-gfm": "1.0.64",
         "@modelcontextprotocol/sdk": "1.26.0",
@@ -34578,15 +35979,22 @@
           "version": "1.0.64",
           "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.64.tgz",
           "integrity": "sha512-8GJ7f9OenE3zkSVII5B6qzIkvgF7C/a20gaASEjM6jWPLPJFFQ2nQ3Ou/kXH1mPUTs9dC9VYs8QXVPvZabKXBQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
         }
       }
     },
     "@n8n/n8n-nodes-langchain": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-2.23.0.tgz",
-      "integrity": "sha512-ANnmr2wptbjOYhvjoononFFh79RIGMtqdzdlNTlRdLeTjZwDOu0FNPGE+VpKW/rJpvSAd5FSHFKAJ27/vtj0vQ==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-2.26.1.tgz",
+      "integrity": "sha512-PVb17ZBOmLaLrW60rlvqRvJzNKxVrk6DSllj3fpab9DklpVegOwvkkyc5hGOI23e8Eqw0Q0X6bFLZJVYNAL3lg==",
       "requires": {
+        "@aws-sdk/client-bedrock-runtime": "3.938.0",
         "@aws-sdk/client-sso-oidc": "3.808.0",
+        "@aws-sdk/credential-providers": "3.808.0",
         "@azure/identity": "4.13.0",
         "@azure/search-documents": "12.1.0",
         "@getzep/zep-cloud": "1.0.6",
@@ -34622,17 +36030,18 @@
         "@microsoft/agents-hosting": "1.2.3",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@mozilla/readability": "0.6.0",
-        "@n8n/ai-utilities": "0.17.0",
-        "@n8n/client-oauth2": "1.7.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@n8n/json-schema-to-zod": "1.9.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/json-schema-to-zod": "1.10.0",
         "@n8n/typeorm": "0.3.20-16",
-        "@n8n/typescript-config": "1.4.0",
+        "@n8n/typescript-config": "1.5.0",
         "@oracle/langchain-oracledb": "0.2.0",
         "@pinecone-database/pinecone": "^5.0.2",
         "@qdrant/js-client-rest": "^1.16.2",
+        "@smithy/node-http-handler": "4.5.0",
         "@supabase/supabase-js": "2.50.0",
         "@xata.io/client": "0.28.4",
         "@zilliz/milvus2-sdk-node": "^2.5.7",
@@ -34654,8 +36063,8 @@
         "mime-types": "3.0.2",
         "mongodb": "^6.17.0",
         "mysql2": "3.17.0",
-        "n8n-nodes-base": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-nodes-base": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "openai": "^6.34.0",
         "pg": "8.17.0",
         "redis": "4.6.14",
@@ -34805,6 +36214,12 @@
             }
           }
         },
+        "@n8n/json-schema-to-zod": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@n8n/json-schema-to-zod/-/json-schema-to-zod-1.10.0.tgz",
+          "integrity": "sha512-GrigkK/oq/cuq/lFa5WxmB34ZGD5aIf6mGVXliePbkXoMU/UaieMmfxOwi+aZ22Gb+J/ANhkgUDFz+olaXXRww==",
+          "requires": {}
+        },
         "@n8n/typeorm": {
           "version": "0.3.20-16",
           "resolved": "https://registry.npmjs.org/@n8n/typeorm/-/typeorm-0.3.20-16.tgz",
@@ -34823,6 +36238,18 @@
             "tarn": "3.0.2",
             "tslib": "^2.5.0",
             "uuid": "^9.0.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+          "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+          "requires": {
+            "@smithy/abort-controller": "^4.2.12",
+            "@smithy/protocol-http": "^5.3.12",
+            "@smithy/querystring-builder": "^4.2.12",
+            "@smithy/types": "^4.13.1",
+            "tslib": "^2.6.2"
           }
         },
         "ansi-styles": {
@@ -34931,11 +36358,38 @@
             "brace-expansion": "^2.0.2"
           }
         },
-        "openai": {
-          "version": "6.39.0",
-          "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-          "integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
-          "requires": {}
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "11.1.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+              "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+            }
+          }
         },
         "path-scurry": {
           "version": "1.11.1",
@@ -34959,15 +36413,33 @@
           "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
           "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
           "peer": true
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        },
+        "zod-to-json-schema": {
+          "version": "3.23.3",
+          "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+          "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+          "requires": {}
         }
       }
     },
     "@n8n/permissions": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.61.0.tgz",
-      "integrity": "sha512-5Dcpew/D7l+EKZX8GVzWlTHQzOdUFEO0K6Z+puQiYVhhK2AUYkwrChrefV7dcAAcCZUvTnIdbtbd0Sg27rl4eQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.63.0.tgz",
+      "integrity": "sha512-KsGqEeElwOWsudYBgrpTRDcu6b9LLRaAnMfiJIstURy7OVdbSSSjJ2I3bAEfg+p/jrFsbJAS4JrKHorEIqyi0g==",
       "requires": {
         "zod": "3.25.67"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        }
       }
     },
     "@n8n/sandbox-client": {
@@ -34979,36 +36451,359 @@
       }
     },
     "@n8n/syslog-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@n8n/syslog-client/-/syslog-client-1.4.0.tgz",
-      "integrity": "sha512-1WYlK9M9qsfkfjpcwmJ8/afjgvpAiKfXH8eCbs8D86xLXSEe72cscOhTe9eNfwbrqcc9EYrz6YrRNpQIZhLUmQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@n8n/syslog-client/-/syslog-client-1.5.0.tgz",
+      "integrity": "sha512-e3W8QwlUU0P7sb9/LUIjmdjm1/PrQV3HjG46T6YD30PmNAxRuj/WZ3nKxVCFLDC3TKDtHioEnmmtmpZK4OHvQw==",
       "requires": {
         "zod": "3.25.67"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        }
       }
     },
     "@n8n/task-runner": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-2.23.0.tgz",
-      "integrity": "sha512-b5P2/u3pPCv3DjG5USTXc5RDmAXZh6BMToe3J7rOopxiyfeup/2xhGGw61InJoXH+78T/rstuxpkZnWF7m6vMQ==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-2.26.1.tgz",
+      "integrity": "sha512-TMwxAKePf5e4FhvLjhiasyDQEhb9PsfcOu4smKdP6RO2OXtMGmgy06fDqv5eQvik4sxRocccCiHyEJcuNXeFmA==",
       "requires": {
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@sentry/node": "^10.36.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@sentry/node": "^10.55.0",
         "acorn": "8.14.0",
         "acorn-walk": "8.3.4",
         "lodash": "4.18.1",
         "luxon": "3.7.2",
-        "n8n-core": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-core": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "ws": "^8.18.0"
+      },
+      "dependencies": {
+        "@aws-sdk/client-s3": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.808.0.tgz",
+          "integrity": "sha512-8RY3Jsm84twmYfiqnMkxznuY6pBX7y2GiuEJVdW1ZJLXRDOiCPkTBHsO6jUwppfMua7HRhO2OTAdWr7aSBAdPw==",
+          "requires": {
+            "@aws-crypto/sha1-browser": "5.2.0",
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.808.0",
+            "@aws-sdk/credential-provider-node": "3.808.0",
+            "@aws-sdk/middleware-bucket-endpoint": "3.808.0",
+            "@aws-sdk/middleware-expect-continue": "3.804.0",
+            "@aws-sdk/middleware-flexible-checksums": "3.808.0",
+            "@aws-sdk/middleware-host-header": "3.804.0",
+            "@aws-sdk/middleware-location-constraint": "3.804.0",
+            "@aws-sdk/middleware-logger": "3.804.0",
+            "@aws-sdk/middleware-recursion-detection": "3.804.0",
+            "@aws-sdk/middleware-sdk-s3": "3.808.0",
+            "@aws-sdk/middleware-ssec": "3.804.0",
+            "@aws-sdk/middleware-user-agent": "3.808.0",
+            "@aws-sdk/region-config-resolver": "3.808.0",
+            "@aws-sdk/signature-v4-multi-region": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@aws-sdk/util-endpoints": "3.808.0",
+            "@aws-sdk/util-user-agent-browser": "3.804.0",
+            "@aws-sdk/util-user-agent-node": "3.808.0",
+            "@aws-sdk/xml-builder": "3.804.0",
+            "@smithy/config-resolver": "^4.1.2",
+            "@smithy/core": "^3.3.1",
+            "@smithy/eventstream-serde-browser": "^4.0.2",
+            "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+            "@smithy/eventstream-serde-node": "^4.0.2",
+            "@smithy/fetch-http-handler": "^5.0.2",
+            "@smithy/hash-blob-browser": "^4.0.2",
+            "@smithy/hash-node": "^4.0.2",
+            "@smithy/hash-stream-node": "^4.0.2",
+            "@smithy/invalid-dependency": "^4.0.2",
+            "@smithy/md5-js": "^4.0.2",
+            "@smithy/middleware-content-length": "^4.0.2",
+            "@smithy/middleware-endpoint": "^4.1.4",
+            "@smithy/middleware-retry": "^4.1.5",
+            "@smithy/middleware-serde": "^4.0.3",
+            "@smithy/middleware-stack": "^4.0.2",
+            "@smithy/node-config-provider": "^4.1.1",
+            "@smithy/node-http-handler": "^4.0.4",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/smithy-client": "^4.2.4",
+            "@smithy/types": "^4.2.0",
+            "@smithy/url-parser": "^4.0.2",
+            "@smithy/util-base64": "^4.0.0",
+            "@smithy/util-body-length-browser": "^4.0.0",
+            "@smithy/util-body-length-node": "^4.0.0",
+            "@smithy/util-defaults-mode-browser": "^4.0.12",
+            "@smithy/util-defaults-mode-node": "^4.0.12",
+            "@smithy/util-endpoints": "^3.0.4",
+            "@smithy/util-middleware": "^4.0.2",
+            "@smithy/util-retry": "^4.0.3",
+            "@smithy/util-stream": "^4.2.0",
+            "@smithy/util-utf8": "^4.0.0",
+            "@smithy/util-waiter": "^4.0.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-flexible-checksums": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
+          "integrity": "sha512-NW1yoTYDH2h8ycqMPNkvW3d1XT2vEeXfXclagL2tv82P7Qt7vPXYcObs/YtETvNZ7hdnmOftJ/IJv7YrFC8vtQ==",
+          "requires": {
+            "@aws-crypto/crc32": "5.2.0",
+            "@aws-crypto/crc32c": "5.2.0",
+            "@aws-crypto/util": "5.2.0",
+            "@aws-sdk/core": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@smithy/is-array-buffer": "^4.0.0",
+            "@smithy/node-config-provider": "^4.1.1",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/types": "^4.2.0",
+            "@smithy/util-middleware": "^4.0.2",
+            "@smithy/util-stream": "^4.2.0",
+            "@smithy/util-utf8": "^4.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-s3": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.808.0.tgz",
+          "integrity": "sha512-qvyJTDf0HIsPpZzBUqhNQm5g8stAn2EOwVsaAolsOHuBsdaBAE/s/NgPzazDlSXwdF0ITvsIouUVDCn4fJGJqQ==",
+          "requires": {
+            "@aws-sdk/core": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@aws-sdk/util-arn-parser": "3.804.0",
+            "@smithy/core": "^3.3.1",
+            "@smithy/node-config-provider": "^4.1.1",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/signature-v4": "^5.1.0",
+            "@smithy/smithy-client": "^4.2.4",
+            "@smithy/types": "^4.2.0",
+            "@smithy/util-config-provider": "^4.0.0",
+            "@smithy/util-middleware": "^4.0.2",
+            "@smithy/util-stream": "^4.2.0",
+            "@smithy/util-utf8": "^4.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/signature-v4-multi-region": {
+          "version": "3.808.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.808.0.tgz",
+          "integrity": "sha512-lQuEB6JK81eKV7fdiktmRq06Y1KCcJbx9fLf7b19nSfYUbJSn/kfSpHPv/tOkJK2HKnN61JsfG19YU8k4SOU8Q==",
+          "requires": {
+            "@aws-sdk/middleware-sdk-s3": "3.808.0",
+            "@aws-sdk/types": "3.804.0",
+            "@smithy/protocol-http": "^5.1.0",
+            "@smithy/signature-v4": "^5.1.0",
+            "@smithy/types": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/xml-builder": {
+          "version": "3.804.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.804.0.tgz",
+          "integrity": "sha512-JbGWp36IG9dgxtvC6+YXwt5WDZYfuamWFtVfK6fQpnmL96dx+GUPOXPKRWdw67WLKf2comHY28iX2d3z35I53Q==",
+          "requires": {
+            "@smithy/types": "^4.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@langchain/core": {
+          "version": "1.1.41",
+          "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+          "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
+          "requires": {
+            "@cfworker/json-schema": "^4.0.2",
+            "@standard-schema/spec": "^1.1.0",
+            "ansi-styles": "^5.0.0",
+            "camelcase": "6",
+            "decamelize": "1.2.0",
+            "js-tiktoken": "^1.0.12",
+            "langsmith": ">=0.5.0 <1.0.0",
+            "mustache": "^4.2.0",
+            "p-queue": "^6.6.2",
+            "uuid": "^11.1.0",
+            "zod": "^3.25.76 || ^4"
+          },
+          "dependencies": {
+            "zod": {
+              "version": "4.4.3",
+              "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+              "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+            }
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        },
+        "file-type": {
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+          "requires": {
+            "readable-web-to-node-stream": "^3.0.0",
+            "strtok3": "^6.2.4",
+            "token-types": "^4.1.1"
+          }
+        },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "n8n-core": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.26.1.tgz",
+          "integrity": "sha512-X0IO6e89aGVA3PUPz0YhE/CwHoipeHaGBVlFs0FHEq+DZq5D21HQkbHT89+OBQLM58Vd5fGE0ceITgeeaSbhPA==",
+          "requires": {
+            "@aws-sdk/client-s3": "3.808.0",
+            "@langchain/core": "1.1.41",
+            "@n8n/backend-common": "1.26.1",
+            "@n8n/client-oauth2": "1.8.0",
+            "@n8n/config": "2.24.0",
+            "@n8n/constants": "0.26.0",
+            "@n8n/decorators": "1.26.1",
+            "@n8n/di": "0.13.0",
+            "@n8n/workflow-sdk": "0.19.1",
+            "@sentry/node": "^10.55.0",
+            "@sentry/node-native": "^10.55.0",
+            "@sentry/profiling-node": "^10.55.0",
+            "axios": "1.16.1",
+            "cache-manager": "5.2.3",
+            "callsites": "3.1.0",
+            "chardet": "2.0.0",
+            "cron": "4.4.0",
+            "fast-glob": "3.2.12",
+            "file-type": "16.5.4",
+            "form-data": "4.0.4",
+            "htmlparser2": "^10.0.0",
+            "http-proxy-agent": "7.0.2",
+            "https-proxy-agent": "7.0.6",
+            "iconv-lite": "0.6.3",
+            "jsonwebtoken": "9.0.3",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "mime-types": "3.0.2",
+            "n8n-workflow": "2.26.1",
+            "nanoid": "3.3.8",
+            "oauth-1.0a": "2.2.6",
+            "p-cancelable": "2.1.1",
+            "picocolors": "1.0.1",
+            "pretty-bytes": "5.6.0",
+            "proxy-from-env": "^1.1.0",
+            "qs": "6.14.2",
+            "ssh2": "1.15.0",
+            "uuid": "11.1.1",
+            "winston": "3.14.2",
+            "xml2js": "0.6.2"
+          },
+          "dependencies": {
+            "mime-types": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+              "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+              "requires": {
+                "mime-db": "^1.54.0"
+              }
+            }
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "ssh2": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+          "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+          "requires": {
+            "asn1": "^0.2.6",
+            "bcrypt-pbkdf": "^1.0.2",
+            "cpu-features": "~0.0.9",
+            "nan": "^2.18.0"
+          }
+        },
+        "strtok3": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+          "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+          "requires": {
+            "@tokenizer/token": "^0.3.0",
+            "peek-readable": "^4.1.0"
+          }
+        },
+        "token-types": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+          "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+          "requires": {
+            "@tokenizer/token": "^0.3.0",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+          "peer": true
+        }
       }
     },
     "@n8n/tournament": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.2.0.tgz",
-      "integrity": "sha512-EY/vqijjYi2LhnKeShNXNtVBJW7lSRGFe5D2ikv5AfDZiLOqneRnNdfwZbv1bTLByRYyzY708KiXF8P66Gr1dg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.3.0.tgz",
+      "integrity": "sha512-tSn3uFKdvXReNdG+VbwNEieSSIEd1V3DGhaD5XD3wIgp3RVX77XGA08h02ov5TYNg6AsQT1LUdicX7LDnlKtvg==",
       "requires": {
         "ast-types": "^0.16.1",
         "esprima-next": "^5.8.4",
@@ -35095,35 +36890,78 @@
       }
     },
     "@n8n/typescript-config": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.4.0.tgz",
-      "integrity": "sha512-HC2rgU/FtbOb6vpC/VvqfOxqeMkmQH/YdZK1y/wel7YgMCJcv92IhjJPehW1Qpp+OUesGTn03VJb4vee/ZEBkw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.5.0.tgz",
+      "integrity": "sha512-lRqZYmU0tRPAlVmUDfHBlgceE3GbQ5Zqkomrxs2wq5Kif8QqokJvB2T2xzYRrP3WGMDQbZqXeKs2E8Dm5t+nIw=="
     },
     "@n8n/utils": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.32.0.tgz",
-      "integrity": "sha512-cXRVSjrhmWsjLO1dsDirFHrIdZo2cVXkDP2hwFpVkqjdoaRqsJ+6rqUmatKG4nNhtp7uhyRw4tMfKj/qc9s/ww==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.34.0.tgz",
+      "integrity": "sha512-JOaQXZLIBBYN0rmXDd8VXK3OwXPMw1PdCXGSy+5xf6arPzm9+gkGRbrPcgh3vv4/sLbtfqyM7O5ohQK/axjMzQ==",
       "requires": {
-        "@n8n/constants": "0.25.0",
+        "@n8n/constants": "0.26.0",
         "nanoid": "3.3.8"
       }
     },
     "@n8n/workflow-sdk": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/workflow-sdk/-/workflow-sdk-0.16.0.tgz",
-      "integrity": "sha512-DoDr7RByG08AfAOepG56ycVd7IACfBxpCrlHRFLBs2LpQ92TOxwy6fLZcqA1gZAxDkz+/FP0Te4HL/EVSfwplQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@n8n/workflow-sdk/-/workflow-sdk-0.19.1.tgz",
+      "integrity": "sha512-vzmczmW9ZJ5265MssVkqUDLkTu3TFcUSPD/sU1uy06bNYQrguI1t01q+l/mIJKAFfV3Pnb6Sb/IRlUUEkasf6w==",
       "requires": {
         "@dagrejs/dagre": "^1.1.4",
         "acorn": "8.14.0",
-        "n8n-workflow": "2.23.0",
-        "uuid": "10.0.0",
+        "n8n-workflow": "2.26.1",
+        "uuid": "11.1.1",
         "zod": "3.25.67"
       },
       "dependencies": {
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
         }
       }
     },
@@ -35210,9 +37048,9 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
     },
     "@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -36136,24 +37974,33 @@
         "node-abi": "^3.89.0"
       }
     },
+    "@sentry-internal/server-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.57.0.tgz",
+      "integrity": "sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==",
+      "requires": {
+        "@sentry/core": "10.57.0"
+      }
+    },
     "@sentry/core": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.54.0.tgz",
-      "integrity": "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg=="
     },
     "@sentry/node": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.54.0.tgz",
-      "integrity": "sha512-Jc31dMBs9aBUv6TXmIPNwv2u18YbfvWQG32IkM3dFWAAoJQhCqLZfN0MEDSf9TeNexIf8qBMZtJRHgHIrWYiGg==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.57.0.tgz",
+      "integrity": "sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==",
       "requires": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/core": "^2.6.1",
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.54.0",
-        "@sentry/node-core": "10.54.0",
-        "@sentry/opentelemetry": "10.54.0",
+        "@sentry-internal/server-utils": "10.57.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/node-core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
         "import-in-the-middle": "^3.0.0"
       },
       "dependencies": {
@@ -36178,41 +38025,61 @@
       }
     },
     "@sentry/node-core": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.54.0.tgz",
-      "integrity": "sha512-QR5RnIK78g0Np2+VWMZ3TatM7C+oX9zIQ1W36o3KOjw0nNcXkWjZT1lEu4me8cp2s8s3hA4qT7fwcciQqkj1UQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.57.0.tgz",
+      "integrity": "sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==",
       "requires": {
-        "@sentry/core": "10.54.0",
-        "@sentry/opentelemetry": "10.54.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
         "import-in-the-middle": "^3.0.0"
       }
     },
     "@sentry/node-native": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-native/-/node-native-10.54.0.tgz",
-      "integrity": "sha512-GmMJFI5swhFRxI1g1MGn2jSx8DzPsYSNV53nTcroS/BviMKRi9CphGgGN0BF2GCenZoNSCaJwVzMt26m9uP/5g==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-native/-/node-native-10.57.0.tgz",
+      "integrity": "sha512-A9r4K63P917mYfIVzc2WRM9LFeht+7r3nCBnwXSCducfJigzYH4EypebydXYnHyDNv0Rb9a5A0viQV0DRxeREQ==",
       "requires": {
         "@sentry-internal/node-native-stacktrace": "^0.5.0",
-        "@sentry/core": "10.54.0",
-        "@sentry/node": "10.54.0"
+        "@sentry/core": "10.57.0",
+        "@sentry/node": "10.57.0"
       }
     },
     "@sentry/opentelemetry": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.54.0.tgz",
-      "integrity": "sha512-58Jk9yMos5DwhamDsNmnoQMSNx0yD9E+h1pZwkw34ve2qB9tv+cys3Oz6nfazT9ZdIsXIgpQntN8AfMXAvv4/g==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.57.0.tgz",
+      "integrity": "sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==",
       "requires": {
-        "@sentry/core": "10.54.0"
+        "@sentry/core": "10.57.0"
       }
     },
     "@sentry/profiling-node": {
-      "version": "10.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.54.0.tgz",
-      "integrity": "sha512-ZyIG+G2fkG43qijOcD5H93F/gnyrAv86jS1wevbOMjIMQxReeQDhZRWPd08rllIAeaYH4v+DjTZrKAX8aR8cyQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.57.0.tgz",
+      "integrity": "sha512-0E6eWOCVOuXTFCrHxyPA0zgjypmeCJAbtgnvLFF+kmdkzeBb02KmXaJ8lre9SSjHmWAeI2jA6URJiKGOxgE0YQ==",
       "requires": {
         "@sentry-internal/node-cpu-profiler": "^2.4.0",
-        "@sentry/core": "10.54.0",
-        "@sentry/node": "10.54.0"
+        "@sentry/core": "10.57.0",
+        "@sentry/node": "10.57.0"
+      }
+    },
+    "@shanghaikid/parquetjs": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@shanghaikid/parquetjs/-/parquetjs-1.8.8.tgz",
+      "integrity": "sha512-uaYXx4yP4cipVU8EZR4OZohiklsazyAcIXtfNEEYBcsMlnz5w4gEvv9vw+cP3yZBv7d1+OQYKfCfKI7oK0iUZQ==",
+      "requires": {
+        "@aws-sdk/client-s3": "^3.864.0",
+        "@types/node-int64": "^0.4.32",
+        "@types/thrift": "^0.10.17",
+        "@zenfs/core": "^2.3.8",
+        "brotli-wasm": "^3.0.1",
+        "bson": "6.10.4",
+        "int53": "^1.0.0",
+        "long": "^5.3.2",
+        "node-int64": "^0.4.0",
+        "snappyjs": "^0.7.0",
+        "thrift": "0.23.0",
+        "varint": "^6.0.0",
+        "xxhash-wasm": "^1.1.0"
       }
     },
     "@simple-git/args-pathspec": {
@@ -36287,6 +38154,15 @@
         }
       }
     },
+    "@smithy/abort-controller": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.16.tgz",
+      "integrity": "sha512-YH0c/t1n8dhzz/NyIEoqoHyn4tBvrtESNRUV+ar6to4eqA3jN2OGqhe9hAicmVCokd+EC3puYXsMAG6PDZVEgg==",
+      "requires": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      }
+    },
     "@smithy/config-resolver": {
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
@@ -36312,77 +38188,77 @@
       }
     },
     "@smithy/core": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
-      "integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "requires": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
-      "integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
       "requires": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.3.4.tgz",
-      "integrity": "sha512-uI00gSvwvBEiVuqpHFcMPGXnVh1XQYuqlQREIX/GUmuwNNTdGRliUI8R71tbfwNLYP7t8E/HVqdohvjoWU13iA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.3.6.tgz",
+      "integrity": "sha512-Ussyv240JxwQP8AmkYdm26wGP/1I8QmIv0ZosgDJDlSzD73FEdj1BOpXMc06VrxX5KxTKhadFNomT2SWutUnpg==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-browser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.4.tgz",
-      "integrity": "sha512-9szC3PfHhYSvWA98CIrD6rB8jS60tfKOPvDlzyD87gsDm8KDnsSpXnwPO1J3bPxg0tWE6Ljzk2YzZV2GBe3nUQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.6.tgz",
+      "integrity": "sha512-BQao/dBhLCJqo953N1hadkcF3M/9G+i6qIgnMupfdpBQomwyhfV7Xfc5jjpCkm8HxfzaWAGrM/2nNnzronFqVQ==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-config-resolver": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.4.tgz",
-      "integrity": "sha512-Q28S5qVeHIGXY4xCO43IFglVCc11HXZlxdhUhcNgiI/ArVDi6SWOMLvWEq1woUQtThNxH3CPbz6l1Z2PT6gl8A==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.6.tgz",
+      "integrity": "sha512-OUoNRXJGZMM4ivoU7QIzOvCLbavD1YnadNEairrtYhTi+gmGhyn3c2wToL9CxEs4Cw2Ab/KeQM39T1K+/e9YdQ==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-node": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.4.tgz",
-      "integrity": "sha512-QxrsfEjVwpx2rzu0ZRc+F1MFSVh9pnjJayHzxjy3l3ru2zp7yt9FsYnDBHmdZV7389wqc1poK84vf5v3lArSaw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.6.tgz",
+      "integrity": "sha512-M6FeKRMi3oecpTy4EL5n1hLPWydw+xInFYQIzjbGYGBnFtW7IlJjnXrKr/Ev1GpMtmw44QCmrl8+ACEFPmRsIg==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
-      "integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
       "requires": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/hash-blob-browser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.4.tgz",
-      "integrity": "sha512-HQw/cCLjoAatHffbVQxanPfDRYFt3NMhAENub1/Pw0iftGYGSS4+4C+G1D7CCJXW5/wR6AIhLT7xPusMqy7qjg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.6.tgz",
+      "integrity": "sha512-/8D8rOFs2VEwvHwsx68sb6nE7XfVr2wbJTbC1YuKBHPhHeMnOt7IHxr7CoT5wBWujdV4fjVoLPn1BXXP4Ijlow==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
@@ -36398,11 +38274,11 @@
       }
     },
     "@smithy/hash-stream-node": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.4.tgz",
-      "integrity": "sha512-wuwVYqGNP9RwLs5hU2nTg8ajL16lA27VX7oGrsarghiqOhAtGYWQQ2VNtotKCBra5t4Od+Epi5jYktm0JwDuIQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.6.tgz",
+      "integrity": "sha512-Ziap41FoxpKqmlO9IE68NeFwPKhUJD4PVNcCQ2tl6IUCPSj0KykIuAPnJNWIQbWXvApwCauhRNlAFdt9KRvDpw==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
@@ -36424,11 +38300,11 @@
       }
     },
     "@smithy/md5-js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.4.tgz",
-      "integrity": "sha512-drsFcLEIjFtmDF8Ta5STY7zTc89L24qL+G2f+YGo2oeoB3OW/6zjhKwW8/nCTS45AAFSyh81UgJ+Jl+Gs0ovnQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.6.tgz",
+      "integrity": "sha512-LYcuBrO9oiajdRFHyFx3FJAWNKrP89s0grI6mcfpwTAeX2ZJ/9Xyi7Imghh9LT6CIcAy6/k6/MpoUiPNjXr1/w==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
@@ -36528,12 +38404,12 @@
       }
     },
     "@smithy/node-http-handler": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz",
-      "integrity": "sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "requires": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       }
     },
@@ -36552,6 +38428,15 @@
       "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "requires": {
         "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.3.6.tgz",
+      "integrity": "sha512-BicTiH0vBGknILtW9mIO+fdO1UY5khbqOMehbGDv6iecYruVSRuEyOazsThj9OSQHw0LfDGQaxj6s6rwWhvggw==",
+      "requires": {
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
@@ -36582,12 +38467,12 @@
       }
     },
     "@smithy/signature-v4": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
-      "integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "requires": {
-        "@smithy/core": "^3.24.4",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       }
     },
@@ -36606,9 +38491,9 @@
       }
     },
     "@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "requires": {
         "tslib": "^2.6.2"
       }
@@ -36761,11 +38646,11 @@
       }
     },
     "@smithy/util-waiter": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.4.tgz",
-      "integrity": "sha512-Qt+W1pLeV/gmsXXUKbcolZqSGwnEdcxM7tqZjtGazkJ4feMUX0Vy+mCZGyhCwLvO8qxsrhYlmRZ7FLGUxJ4Scg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.6.tgz",
+      "integrity": "sha512-oTt3OP9NcJkrySCSCCdSbP6XLSMNgOmt/ulaiYtb0Ng6tfEWtXQ1mwfyqmLd+GapmDUjbU2mgkf7QIq9H4ij/g==",
       "requires": {
-        "@smithy/core": "^3.24.4",
+        "@smithy/core": "^3.24.6",
         "tslib": "^2.6.2"
       }
     },
@@ -36901,14 +38786,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
-    },
-    "@types/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/body-parser": {
       "version": "1.19.6",
@@ -37236,23 +39113,25 @@
       "optional": true
     },
     "@zenfs/core": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-1.11.4.tgz",
-      "integrity": "sha512-jFihhedKitw1X9rlImtaca4KTs1Xk9awo4GxUemqt2ucE1jLi10lyRfFFbiYXZsFDkuCWGHwEQwv7BeDIEXMbQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-2.5.6.tgz",
+      "integrity": "sha512-1BLPS6fsBN2keGDErbz548Cu6fT0xbVQlrVYNK5OAr9aviR2mC/F/4wxdb+dQZ4P4pVxxHI2DVouyniZ8yHxTw==",
       "requires": {
-        "@types/node": "^22.10.1",
+        "@types/node": "^25.2.0",
         "buffer": "^6.0.3",
         "eventemitter3": "^5.0.1",
+        "kerium": "^1.3.4",
+        "memium": "^0.4.0",
         "readable-stream": "^4.5.2",
-        "utilium": "^1.3.3"
+        "utilium": "^3.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "22.19.19",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-          "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+          "version": "25.9.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+          "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
           "requires": {
-            "undici-types": "~6.21.0"
+            "undici-types": ">=7.24.0 <7.24.7"
           }
         },
         "buffer": {
@@ -37282,26 +39161,26 @@
           }
         },
         "undici-types": {
-          "version": "6.21.0",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+          "version": "7.24.6",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+          "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
         }
       }
     },
     "@zilliz/milvus2-sdk-node": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/@zilliz/milvus2-sdk-node/-/milvus2-sdk-node-2.6.14.tgz",
-      "integrity": "sha512-S/DEVvzVnFmxoRCnWA9MBaMgSa1t3LEVKex+1+iJEZFPmrpk0OA9tUVfTgbNvzvV/JlWLH68h7vOAPWz/CsXzQ==",
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/@zilliz/milvus2-sdk-node/-/milvus2-sdk-node-2.6.17.tgz",
+      "integrity": "sha512-Z+fCxhuHLV4kogU1T5SS9hDJqLH3KBEceU5snqDV/WDl6uxgNomqZY9md8TTRkHBISqNzDawEaZsi4MF6Y0oWA==",
       "requires": {
-        "@dsnp/parquetjs": "^1.8.7",
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@petamoriken/float16": "^3.8.6",
+        "@shanghaikid/parquetjs": "1.8.8",
         "dayjs": "^1.11.7",
         "generic-pool": "^3.9.0",
         "lru-cache": "^9.1.2",
-        "protobufjs": "^7.2.6",
+        "protobufjs": "^7.5.8",
         "winston": "^3.9.0"
       },
       "dependencies": {
@@ -37429,24 +39308,14 @@
       }
     },
     "ai": {
-      "version": "6.0.191",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.191.tgz",
-      "integrity": "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==",
+      "version": "6.0.199",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.199.tgz",
+      "integrity": "sha512-6H9RPEjzBQECM+eU1JxAh6jHcZPU/6q5QZ8D8QV8agubf0Mm/kcBlwqrFcFtup6RQzmEvMkVaQOoLCZ8bQ13lA==",
       "requires": {
-        "@ai-sdk/gateway": "3.0.120",
+        "@ai-sdk/gateway": "3.0.127",
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@opentelemetry/api": "^1.9.0"
-      },
-      "dependencies": {
-        "@ai-sdk/provider": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-          "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-          "requires": {
-            "json-schema": "^0.4.0"
-          }
-        }
       }
     },
     "ajv": {
@@ -37525,6 +39394,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+    },
+    "anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA=="
     },
     "app-root-path": {
       "version": "3.1.0",
@@ -37994,9 +39868,9 @@
       "integrity": "sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg=="
     },
     "bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ=="
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="
     },
     "buffer": {
       "version": "5.6.0",
@@ -38379,13 +40253,6 @@
         "chromadb-js-bindings-linux-x64-gnu": "^1.3.3",
         "chromadb-js-bindings-win32-x64-msvc": "^1.3.3",
         "semver": "^7.7.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.8.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-          "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="
-        }
       }
     },
     "chromadb-js-bindings-darwin-arm64": {
@@ -38665,9 +40532,9 @@
       "optional": true
     },
     "console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.16.1.tgz",
+      "integrity": "sha512-Sc9FRJ4O9xKGNrvulNdPfK5SyBcZ6lcaRnDE4AQ/uw6IDtjHhsqyzzqcnMikjyGaiOOF2tNOKoBhbVjRvFy9Lw==",
       "requires": {
         "simple-wcswidth": "^1.1.2"
       }
@@ -39423,9 +41290,9 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -39465,6 +41332,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+    },
+    "eslint-config-riot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
+      "integrity": "sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==",
+      "peer": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -40333,9 +42206,9 @@
       }
     },
     "hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="
     },
     "html-encoding-sniffer": {
       "version": "4.0.0",
@@ -40612,9 +42485,9 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
+      "integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
       "requires": {
         "acorn": "^8.15.0",
         "acorn-import-attributes": "^1.9.5",
@@ -40646,24 +42519,6 @@
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "optional": true
-    },
-    "infisical-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/infisical-node/-/infisical-node-1.3.0.tgz",
-      "integrity": "sha512-tTnnExRAO/ZyqiRdnSlBisErNToYWgtunMWh+8opClEt5qjX7l6HC/b4oGo2AuR2Pf41IR+oqo+dzkM1TCvlUA==",
-      "requires": {
-        "axios": "^1.3.3",
-        "dotenv": "^16.0.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "16.4.5",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-          "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
-        }
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -41368,6 +43223,14 @@
       "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
       "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA=="
     },
+    "kerium": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/kerium/-/kerium-1.3.9.tgz",
+      "integrity": "sha512-uoiTcutvUOjOpck8mmUUq7EsuNPhdfFoYMVehLmJGfdLmWC3nABU8KB63MQM0ydkAM4q+2zZmRIKovbx2LF8iA==",
+      "requires": {
+        "utilium": "^3.0.0"
+      }
+    },
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -41386,40 +43249,40 @@
       },
       "dependencies": {
         "@langchain/langgraph": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-          "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.7.tgz",
+          "integrity": "sha512-6WNskiu3bpy3XFwiD9cm4n2QapnFVX7dqYeJzuEAUGp9R3vbxngRVyb5+Myp5Rz4GCFXGXuhcFSjLVRHPhsNtQ==",
           "requires": {
-            "@langchain/langgraph-checkpoint": "^1.0.2",
-            "@langchain/langgraph-sdk": "~1.9.4",
-            "@langchain/protocol": "^0.0.15",
+            "@langchain/langgraph-checkpoint": "^1.0.4",
+            "@langchain/langgraph-sdk": "~1.9.19",
+            "@langchain/protocol": "^0.0.16",
             "@standard-schema/spec": "1.1.0",
-            "uuid": "^10.0.0"
+            "uuid": "^14.0.0"
           },
           "dependencies": {
             "uuid": {
-              "version": "10.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-              "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+              "version": "14.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+              "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="
             }
           }
         },
         "@langchain/langgraph-sdk": {
-          "version": "1.9.8",
-          "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.8.tgz",
-          "integrity": "sha512-t7HcTy5QL0taI4Zm096yWK5m99n0uW898E7fE8ub4h2+0Ylype5I9Ph3oAB2kCRzTtT/fVwDhsj90t8/c+aNAw==",
+          "version": "1.9.20",
+          "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.20.tgz",
+          "integrity": "sha512-waZQNUN6apVg3jvDApy16wUGwrCvJB8WXHbIPvVrrUZHObqx0w5tk7P/Ite5Qvu4abWrvNtrmqk2zmcqCx7jVw==",
           "requires": {
-            "@langchain/protocol": "^0.0.15",
+            "@langchain/protocol": "^0.0.16",
             "@types/json-schema": "^7.0.15",
             "p-queue": "^9.0.1",
             "p-retry": "^7.1.1",
-            "uuid": "^13.0.0"
+            "uuid": "^14.0.0"
           },
           "dependencies": {
             "uuid": {
-              "version": "13.0.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-              "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
+              "version": "14.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+              "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="
             }
           }
         },
@@ -41454,11 +43317,6 @@
           "version": "11.1.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
           "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
-        },
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
         }
       }
     },
@@ -41471,27 +43329,11 @@
       }
     },
     "ldapts": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-4.2.6.tgz",
-      "integrity": "sha512-r1eOj2PtTJi+9aZxLirktoHntuYXlbQD9ZXCjiZmJx0VBQtBcWc+rueqABuh/AxMcFHNPDSJLJAXxoj5VevTwQ==",
+      "version": "8.1.7",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.7.tgz",
+      "integrity": "sha512-TJl6T92eIwMf/OJ0hDfKVa6ISwzo+lqCWCI5Mf//ARlKa3LKQZaSrme/H2rCRBhW0DZCQlrsV+fgoW5YHRNLUw==",
       "requires": {
-        "@types/asn1": ">=0.2.0",
-        "@types/node": ">=14",
-        "@types/uuid": ">=9",
-        "asn1": "~0.2.6",
-        "debug": "~4.3.4",
-        "strict-event-emitter-types": "~2.0.0",
-        "uuid": "~9.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-          "requires": {
-            "ms": "^2.1.3"
-          }
-        }
+        "strict-event-emitter-types": "2.0.0"
       }
     },
     "leac": {
@@ -41526,9 +43368,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.3.tgz",
-      "integrity": "sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA=="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q=="
     },
     "libqp": {
       "version": "2.1.1",
@@ -42054,6 +43896,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "memium": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/memium/-/memium-0.4.5.tgz",
+      "integrity": "sha512-mnmHWWlcyKnkKSSU0qL1Jsg+CsoikVZ2xsOatAN89R+j4V3m3WlQr0nUoqcjKDyUVF5ZGdNinRiZGVd+7A+TJQ==",
+      "requires": {
+        "kerium": "^1.3.2",
+        "utilium": "^3.0.0"
+      }
     },
     "memory-pager": {
       "version": "1.5.0",
@@ -42602,13 +44453,6 @@
         "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^6.10.4",
         "mongodb-connection-string-url": "^3.0.2"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "6.10.4",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-          "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="
-        }
       }
     },
     "mongodb-connection-string-url": {
@@ -42829,47 +44673,48 @@
       }
     },
     "n8n": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n/-/n8n-2.23.0.tgz",
-      "integrity": "sha512-XY2PHnQ9cTSNRBlzIXFJ/peiWylytK/rlnfoSXomu8AGqRNHK4YgTbsJ61xj6Gk5hCLO5wSyUXH5hxORzNna3A==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/n8n/-/n8n-2.26.2.tgz",
+      "integrity": "sha512-1o6zrLCHMtOgCBevbfz7Q15FHAWKPu0wLz7yNBms2jP+qe6aQrojVYwwo+3nzu4Dor4zbd1ek9VwhVxD5bp0Hg==",
       "requires": {
         "@1password/connect": "1.4.2",
-        "@ai-sdk/anthropic": "3.0.58",
+        "@ai-sdk/anthropic": "^3.0.81",
         "@apidevtools/json-schema-ref-parser": "12.0.2",
         "@aws-sdk/client-secrets-manager": "3.808.0",
         "@azure/identity": "4.13.0",
         "@azure/keyvault-secrets": "4.8.0",
-        "@chat-adapter/linear": "^4.26.0",
-        "@chat-adapter/slack": "^4.26.0",
-        "@chat-adapter/state-memory": "^4.26.0",
-        "@chat-adapter/telegram": "^4.26.0",
+        "@chat-adapter/linear": "^4.28.1",
+        "@chat-adapter/slack": "^4.28.1",
+        "@chat-adapter/state-memory": "^4.28.1",
+        "@chat-adapter/telegram": "^4.28.1",
         "@google-cloud/secret-manager": "5.6.0",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@n8n_io/ai-assistant-sdk": "1.21.0",
         "@n8n_io/license-sdk": "2.25.0",
-        "@n8n/agents": "0.9.0",
-        "@n8n/ai-node-sdk": "0.14.0",
-        "@n8n/ai-utilities": "0.17.0",
-        "@n8n/ai-workflow-builder": "1.23.0",
-        "@n8n/api-types": "1.23.0",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/chat-hub": "1.16.0",
-        "@n8n/client-oauth2": "1.7.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/db": "1.23.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@n8n/expression-runtime": "0.15.0",
-        "@n8n/instance-ai": "1.8.0",
-        "@n8n/n8n-nodes-langchain": "2.23.0",
-        "@n8n/permissions": "0.61.0",
-        "@n8n/syslog-client": "1.4.0",
-        "@n8n/task-runner": "2.23.0",
+        "@n8n/agents": "0.11.0",
+        "@n8n/ai-node-sdk": "0.16.0",
+        "@n8n/ai-utilities": "0.19.0",
+        "@n8n/ai-workflow-builder": "1.26.1",
+        "@n8n/api-types": "1.26.1",
+        "@n8n/backend-common": "1.26.1",
+        "@n8n/chat-hub": "1.19.1",
+        "@n8n/client-oauth2": "1.8.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/constants": "0.26.0",
+        "@n8n/db": "1.26.1",
+        "@n8n/decorators": "1.26.1",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/expression-runtime": "0.17.0",
+        "@n8n/instance-ai": "1.11.1",
+        "@n8n/mcp-apps": "0.3.0",
+        "@n8n/n8n-nodes-langchain": "2.26.1",
+        "@n8n/permissions": "0.63.0",
+        "@n8n/syslog-client": "1.5.0",
+        "@n8n/task-runner": "2.26.1",
         "@n8n/typeorm": "0.3.20-17",
-        "@n8n/utils": "1.32.0",
-        "@n8n/workflow-sdk": "0.16.0",
+        "@n8n/utils": "1.34.0",
+        "@n8n/workflow-sdk": "0.19.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.217.0",
         "@opentelemetry/instrumentation": "^0.217.0",
@@ -42880,14 +44725,14 @@
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@parcel/watcher": "^2.5.1",
         "@rudderstack/rudder-sdk-node": "3.0.5",
-        "@sentry/node": "^10.36.0",
+        "@sentry/node": "^10.55.0",
         "aws4": "1.11.0",
         "axios": "1.16.1",
         "bcryptjs": "2.4.3",
         "bull": "4.16.4",
         "cache-manager": "5.2.3",
         "change-case": "4.1.2",
-        "chat": "^4.26.0",
+        "chat": "^4.28.1",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.0",
         "compression": "1.8.1",
@@ -42904,13 +44749,13 @@
         "express-rate-limit": "7.5.0",
         "fast-glob": "3.2.12",
         "fast-json-patch": "^3.1.1",
+        "fastest-levenshtein": "1.0.16",
         "flat": "5.0.2",
         "flatted": "3.4.2",
         "formidable": "3.5.4",
         "handlebars": "4.7.9",
         "helmet": "8.1.0",
         "http-proxy-middleware": "^3.0.5",
-        "infisical-node": "1.3.0",
         "ioredis": "5.3.2",
         "isbot": "3.6.13",
         "isolated-vm": "^6.1.2",
@@ -42919,22 +44764,23 @@
         "jsonschema": "1.4.1",
         "jsonwebtoken": "9.0.3",
         "langsmith": "0.6.0",
-        "ldapts": "4.2.6",
+        "ldapts": "8.1.7",
         "lodash": "4.18.1",
         "luxon": "3.7.2",
-        "n8n-core": "2.23.0",
-        "n8n-editor-ui": "2.23.0",
-        "n8n-nodes-base": "2.23.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-core": "2.26.1",
+        "n8n-editor-ui": "2.26.1",
+        "n8n-nodes-base": "2.26.1",
+        "n8n-workflow": "2.26.1",
         "nanoid": "3.3.8",
         "nodemailer": "7.0.11",
         "oauth-1.0a": "2.2.6",
         "open": "7.4.2",
-        "openid-client": "6.5.0",
+        "openid-client": "6.8.4",
         "otpauth": "9.1.1",
         "p-cancelable": "2.1.1",
         "p-lazy": "3.1.0",
         "p-limit": "^3.1.0",
+        "pdf-parse": "2.4.5",
         "pg": "8.17.0",
         "picocolors": "1.0.1",
         "pkce-challenge": "5.0.0",
@@ -42946,7 +44792,7 @@
         "reflect-metadata": "0.2.2",
         "replacestream": "4.0.3",
         "samlify": "2.13.0",
-        "semver": "7.5.4",
+        "semver": "7.7.3",
         "shelljs": "0.8.5",
         "simple-git": "3.36.0",
         "source-map-support": "0.5.21",
@@ -42956,7 +44802,7 @@
         "swagger-ui-express": "5.0.1",
         "tar": "^7.5.11",
         "undici": "^7.16.0",
-        "uuid": "10.0.0",
+        "uuid": "11.1.1",
         "validator": "13.15.22",
         "ws": "8.20.1",
         "xml2js": "0.6.2",
@@ -42966,59 +44812,6 @@
         "yargs-parser": "21.1.1",
         "zod": "3.25.67",
         "zod-to-json-schema": "3.23.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
-        }
-      }
-    },
-    "n8n-core": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.23.0.tgz",
-      "integrity": "sha512-GHadiHhekYWLDeLA7UfqS4XCjdtX2unxZUzOHyQCEWyDUPmygA4SSucxXmNFbCQTAG3MywdlgMB/mdMw+4x6kw==",
-      "requires": {
-        "@aws-sdk/client-s3": "3.808.0",
-        "@langchain/core": "1.1.41",
-        "@n8n/backend-common": "1.23.0",
-        "@n8n/client-oauth2": "1.7.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/constants": "0.25.0",
-        "@n8n/decorators": "1.23.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/workflow-sdk": "0.16.0",
-        "@sentry/node": "^10.36.0",
-        "@sentry/node-native": "^10.36.0",
-        "@sentry/profiling-node": "^10.36.0",
-        "axios": "1.16.1",
-        "callsites": "3.1.0",
-        "chardet": "2.0.0",
-        "cron": "4.4.0",
-        "fast-glob": "3.2.12",
-        "file-type": "16.5.4",
-        "form-data": "4.0.4",
-        "htmlparser2": "^10.0.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "iconv-lite": "0.6.3",
-        "jsonwebtoken": "9.0.3",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "mime-types": "3.0.2",
-        "n8n-workflow": "2.23.0",
-        "nanoid": "3.3.8",
-        "oauth-1.0a": "2.2.6",
-        "p-cancelable": "2.1.1",
-        "picocolors": "1.0.1",
-        "pretty-bytes": "5.6.0",
-        "proxy-from-env": "^1.1.0",
-        "qs": "6.14.2",
-        "ssh2": "1.15.0",
-        "uuid": "10.0.0",
-        "winston": "3.14.2",
-        "xml2js": "0.6.2"
       },
       "dependencies": {
         "@aws-sdk/client-s3": {
@@ -43084,31 +44877,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@aws-sdk/middleware-bucket-endpoint": {
-          "version": "3.808.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.808.0.tgz",
-          "integrity": "sha512-wEPlNcs8dir9lXbuviEGtSzYSxG/NRKQrJk5ybOc7OpPGHovsN+QhDOdY3lcjOFdwMTiMIG9foUkPz3zBpLB1A==",
-          "requires": {
-            "@aws-sdk/types": "3.804.0",
-            "@aws-sdk/util-arn-parser": "3.804.0",
-            "@smithy/node-config-provider": "^4.1.1",
-            "@smithy/protocol-http": "^5.1.0",
-            "@smithy/types": "^4.2.0",
-            "@smithy/util-config-provider": "^4.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-expect-continue": {
-          "version": "3.804.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.804.0.tgz",
-          "integrity": "sha512-YW1hySBolALMII6C8y7Z0CRG2UX1dGJjLEBNFeefhO/xP7ZuE1dvnmfJGaEuBMnvc3wkRS63VZ3aqX6sevM1CA==",
-          "requires": {
-            "@aws-sdk/types": "3.804.0",
-            "@smithy/protocol-http": "^5.1.0",
-            "@smithy/types": "^4.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "@aws-sdk/middleware-flexible-checksums": {
           "version": "3.808.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.808.0.tgz",
@@ -43126,16 +44894,6 @@
             "@smithy/util-middleware": "^4.0.2",
             "@smithy/util-stream": "^4.2.0",
             "@smithy/util-utf8": "^4.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-location-constraint": {
-          "version": "3.804.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.804.0.tgz",
-          "integrity": "sha512-AMtKnllIWKgoo7hiJfphLYotEwTERfjVMO2+cKAncz9w1g+bnYhHxiVhJJoR94y047c06X4PU5MsTxvdQ73Znw==",
-          "requires": {
-            "@aws-sdk/types": "3.804.0",
-            "@smithy/types": "^4.2.0",
             "tslib": "^2.6.2"
           }
         },
@@ -43157,16 +44915,6 @@
             "@smithy/util-middleware": "^4.0.2",
             "@smithy/util-stream": "^4.2.0",
             "@smithy/util-utf8": "^4.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-ssec": {
-          "version": "3.804.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.804.0.tgz",
-          "integrity": "sha512-Tk8jK0gOIUBvEPTz/wwSlP1V70zVQ3QYqsLPAjQRMO6zfOK9ax31dln3MgKvFDJxBydS2tS3wsn53v+brxDxTA==",
-          "requires": {
-            "@aws-sdk/types": "3.804.0",
-            "@smithy/types": "^4.2.0",
             "tslib": "^2.6.2"
           }
         },
@@ -43210,16 +44958,21 @@
             "zod": "^3.25.76 || ^4"
           },
           "dependencies": {
-            "uuid": {
-              "version": "11.1.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-              "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
-            },
             "zod": {
               "version": "4.4.3",
               "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
               "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
             }
+          }
+        },
+        "@n8n/api-types": {
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.26.1.tgz",
+          "integrity": "sha512-YU4HFIARKZdhXfdyAeKCkUFJrJpMgIuEV2prh5DO5sQAp5KSdd5SYLW2b/p2Xn/Osv4o+dVcQuqU+E3e8NtRjQ==",
+          "requires": {
+            "@n8n/permissions": "0.63.0",
+            "n8n-workflow": "2.26.1",
+            "xss": "1.0.15"
           }
         },
         "ansi-styles": {
@@ -43247,16 +45000,6 @@
             "es-set-tostringtag": "^2.1.0",
             "hasown": "^2.0.2",
             "mime-types": "^2.1.12"
-          },
-          "dependencies": {
-            "mime-types": {
-              "version": "2.1.35",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-              "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-              "requires": {
-                "mime-db": "1.52.0"
-              }
-            }
           }
         },
         "iconv-lite": {
@@ -43267,19 +45010,103 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
-        "mime-types": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-          "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "n8n-core": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.26.1.tgz",
+          "integrity": "sha512-X0IO6e89aGVA3PUPz0YhE/CwHoipeHaGBVlFs0FHEq+DZq5D21HQkbHT89+OBQLM58Vd5fGE0ceITgeeaSbhPA==",
           "requires": {
-            "mime-db": "^1.54.0"
+            "@aws-sdk/client-s3": "3.808.0",
+            "@langchain/core": "1.1.41",
+            "@n8n/backend-common": "1.26.1",
+            "@n8n/client-oauth2": "1.8.0",
+            "@n8n/config": "2.24.0",
+            "@n8n/constants": "0.26.0",
+            "@n8n/decorators": "1.26.1",
+            "@n8n/di": "0.13.0",
+            "@n8n/workflow-sdk": "0.19.1",
+            "@sentry/node": "^10.55.0",
+            "@sentry/node-native": "^10.55.0",
+            "@sentry/profiling-node": "^10.55.0",
+            "axios": "1.16.1",
+            "cache-manager": "5.2.3",
+            "callsites": "3.1.0",
+            "chardet": "2.0.0",
+            "cron": "4.4.0",
+            "fast-glob": "3.2.12",
+            "file-type": "16.5.4",
+            "form-data": "4.0.4",
+            "htmlparser2": "^10.0.0",
+            "http-proxy-agent": "7.0.2",
+            "https-proxy-agent": "7.0.6",
+            "iconv-lite": "0.6.3",
+            "jsonwebtoken": "9.0.3",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "mime-types": "3.0.2",
+            "n8n-workflow": "2.26.1",
+            "nanoid": "3.3.8",
+            "oauth-1.0a": "2.2.6",
+            "p-cancelable": "2.1.1",
+            "picocolors": "1.0.1",
+            "pretty-bytes": "5.6.0",
+            "proxy-from-env": "^1.1.0",
+            "qs": "6.14.2",
+            "ssh2": "1.15.0",
+            "uuid": "11.1.1",
+            "winston": "3.14.2",
+            "xml2js": "0.6.2"
           },
           "dependencies": {
-            "mime-db": {
-              "version": "1.54.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-              "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+            "mime-types": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+              "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+              "requires": {
+                "mime-db": "^1.54.0"
+              }
             }
+          }
+        },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
+        "ssh2": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
+          "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+          "requires": {
+            "asn1": "^0.2.6",
+            "bcrypt-pbkdf": "^1.0.2",
+            "cpu-features": "~0.0.9",
+            "nan": "^2.18.0"
           }
         },
         "strtok3": {
@@ -43301,29 +45128,40 @@
           }
         },
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+        },
+        "zod-to-json-schema": {
+          "version": "3.23.3",
+          "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+          "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+          "requires": {}
         }
       }
     },
     "n8n-editor-ui": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-2.23.0.tgz",
-      "integrity": "sha512-sKX+33UKneD473Ip7Hn+RK/GujLR/UDvGEonWdCaHiqHFwKg8TK/j4Hl+MPT10/qgJNLDoziPKBA8YZeRZEcLw=="
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-2.26.1.tgz",
+      "integrity": "sha512-/Zh9oR1XNHivjX7I83GZW4TbxwP4822cJfwE07C3UYZ1UUkP6yAEFVFPVSJilwT4ma3G7Zn/fksU5EmyHcAVkA=="
     },
     "n8n-nodes-base": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-2.23.0.tgz",
-      "integrity": "sha512-fTZjCagna3gH988ms71TGLWEfeYKFf9Rx41IV/T38m8A032OBzEX09+1x4TWXaYtRxtQdRnLs3pKeitjbfwBmA==",
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-2.26.1.tgz",
+      "integrity": "sha512-kuKaDHfFHWwH/M9cVzUhO5/DXZbxO8Ug/VhYaC0GiYcsFuVsiJdJDIQ+Xz1LsEoPCMdlmlh5x9NlZTW37Alnqw==",
       "requires": {
         "@aws-sdk/client-sso-oidc": "3.808.0",
         "@kafkajs/confluent-schema-registry": "3.8.0",
         "@mozilla/readability": "0.6.0",
-        "@n8n/config": "2.22.0",
-        "@n8n/di": "0.12.0",
-        "@n8n/errors": "0.8.0",
-        "@n8n/imap": "0.20.0",
+        "@n8n/config": "2.24.0",
+        "@n8n/di": "0.13.0",
+        "@n8n/errors": "0.9.0",
+        "@n8n/imap": "0.21.0",
         "@thednp/dommatrix": "^2.0.12",
         "alasql": "4.4.0",
         "amqplib": "0.10.6",
@@ -43353,7 +45191,7 @@
         "jsdom": "23.0.1",
         "jsonwebtoken": "9.0.3",
         "kafkajs": "2.2.4",
-        "ldapts": "4.2.6",
+        "ldapts": "8.1.7",
         "lodash": "4.18.1",
         "lossless-json": "1.0.5",
         "luxon": "3.7.2",
@@ -43365,7 +45203,7 @@
         "mqtt": "5.7.2",
         "mssql": "10.0.2",
         "mysql2": "3.17.0",
-        "n8n-workflow": "2.23.0",
+        "n8n-workflow": "2.26.1",
         "node-html-markdown": "1.2.0",
         "node-ssh": "13.2.0",
         "nodemailer": "7.0.11",
@@ -43375,20 +45213,22 @@
         "pg": "8.17.0",
         "pg-promise": "11.9.1",
         "promise-ftp": "1.3.5",
+        "proxy-from-env": "^1.1.0",
         "redis": "4.6.14",
         "rfc2047": "4.0.1",
         "rhea": "3.0.4",
         "rrule": "2.8.1",
         "rss-parser": "3.13.0",
         "sanitize-html": "2.12.1",
-        "semver": "7.5.4",
+        "semver": "7.7.3",
         "showdown": "2.1.0",
         "simple-git": "3.36.0",
         "snowflake-sdk": "2.1.0",
         "ssh2-sftp-client": "12.1.0",
         "tmp-promise": "3.0.3",
         "ts-ics": "1.2.2",
-        "uuid": "10.0.0",
+        "undici": "^6.24.0",
+        "uuid": "11.1.1",
         "vm2": "3.11.5",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "xml2js": "0.6.2",
@@ -43470,6 +45310,33 @@
           "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
           "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
         },
+        "form-data": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+          "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
+            "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "mime-db": {
+              "version": "1.52.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+              "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+            },
+            "mime-types": {
+              "version": "2.1.35",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+              "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+              "requires": {
+                "mime-db": "1.52.0"
+              }
+            }
+          }
+        },
         "htmlparser2": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -43512,6 +45379,32 @@
             "mongodb-connection-string-url": "^3.0.0"
           }
         },
+        "n8n-workflow": {
+          "version": "2.26.1",
+          "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.26.1.tgz",
+          "integrity": "sha512-kXU3UwodHR8m/DzAKaKSuVqhY6CWVeF9/9L8c50YtUOdd7Iv4so4mpd58l+1S2N75hH91q/HnEwTMfZYqDI8eg==",
+          "requires": {
+            "@n8n/errors": "0.9.0",
+            "@n8n/expression-runtime": "0.17.0",
+            "@n8n/tournament": "1.3.0",
+            "ast-types": "0.16.1",
+            "callsites": "3.1.0",
+            "esprima-next": "5.8.4",
+            "form-data": "4.0.4",
+            "jmespath": "0.16.0",
+            "js-base64": "3.7.8",
+            "jsonrepair": "3.13.2",
+            "jssha": "3.3.1",
+            "lodash": "4.18.1",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "recast": "0.22.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5",
+            "uuid": "11.1.1",
+            "xml2js": "0.6.2"
+          }
+        },
         "parse5": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -43525,43 +45418,103 @@
             "parse5": "^6.0.1"
           }
         },
+        "ts-ics": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/ts-ics/-/ts-ics-1.2.2.tgz",
+          "integrity": "sha512-L7T5JQi99qQ2Uv7AoCHUZ8Mx1bJYo7qBZtBckuHueR90I3WVdW5NC/tOqTVgu18c3zj08du+xlgWlTIcE+Foxw==",
+          "requires": {
+            "date-fns-tz": "^2.0.0"
+          }
+        },
+        "undici": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+          "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="
+        },
         "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+          "peer": true
         }
       }
     },
     "n8n-workflow": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.23.0.tgz",
-      "integrity": "sha512-TCpVmYmpyb/jqmuRnXW9xh8wpcIK7ox1B45NVUiTOUwC79tBse2Ss0y486NetesOhiwU4cjYgjNDbTQPOcCW0w==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.16.0.tgz",
+      "integrity": "sha512-JoDvHLvV4QZQBCDVQl5xkrGOmPmsacLO4TkJkErCzMmiEqIej+h14J6eCUY7gbxBj8V+GIBlpqyO63akJbXRQg==",
+      "peer": true,
       "requires": {
-        "@n8n/errors": "0.8.0",
-        "@n8n/expression-runtime": "0.15.0",
-        "@n8n/tournament": "1.2.0",
+        "@n8n/errors": "0.6.0",
+        "@n8n/expression-runtime": "0.8.0",
+        "@n8n/tournament": "1.0.6",
         "ast-types": "0.16.1",
         "callsites": "3.1.0",
         "esprima-next": "5.8.4",
         "form-data": "4.0.4",
         "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
+        "js-base64": "3.7.2",
         "jsonrepair": "3.13.2",
         "jssha": "3.3.1",
-        "lodash": "4.18.1",
+        "lodash": "4.17.23",
         "luxon": "3.7.2",
         "md5": "2.3.0",
         "recast": "0.22.0",
         "title-case": "3.0.3",
         "transliteration": "2.3.5",
         "uuid": "10.0.0",
-        "xml2js": "0.6.2"
+        "xml2js": "0.6.2",
+        "zod": "3.25.67"
       },
       "dependencies": {
+        "@n8n/errors": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.6.0.tgz",
+          "integrity": "sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==",
+          "peer": true,
+          "requires": {
+            "callsites": "3.1.0"
+          }
+        },
+        "@n8n/expression-runtime": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.8.0.tgz",
+          "integrity": "sha512-SnBLoLsrGUCS9cVrF20UuSyKcMv+y6Clc4+EA9zLjX85S0GPwOAdApUVSsi81ejPAqMlm42TW1L6r7NpcK/ztQ==",
+          "peer": true,
+          "requires": {
+            "@n8n/tournament": "1.0.6",
+            "isolated-vm": "^6.0.2",
+            "js-base64": "3.7.2",
+            "jssha": "3.3.1",
+            "lodash": "4.17.23",
+            "luxon": "3.7.2",
+            "md5": "2.3.0",
+            "title-case": "3.0.3",
+            "transliteration": "2.3.5"
+          }
+        },
+        "@n8n/tournament": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.0.6.tgz",
+          "integrity": "sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==",
+          "peer": true,
+          "requires": {
+            "@n8n_io/riot-tmpl": "^4.0.1",
+            "ast-types": "^0.16.1",
+            "esprima-next": "^5.8.4",
+            "recast": "^0.22.0"
+          }
+        },
         "form-data": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
           "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+          "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -43570,10 +45523,29 @@
             "mime-types": "^2.1.12"
           }
         },
+        "js-base64": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+          "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
+          "peer": true
+        },
+        "lodash": {
+          "version": "4.17.23",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+          "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+          "peer": true
+        },
         "uuid": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+          "peer": true
+        },
+        "zod": {
+          "version": "3.25.67",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+          "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+          "peer": true
         }
       }
     },
@@ -43939,9 +45911,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A=="
     },
     "oauth-1.0a": {
       "version": "2.2.6",
@@ -43949,9 +45921,9 @@
       "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
     },
     "oauth4webapi": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.7.0.tgz",
-      "integrity": "sha512-Q52wTPUWPsVLVVmTViXPQFMW2h2xv2jnDGxypjpelCFKaOjLsm7AxYuOk1oQgFm95VNDbuggasu9htXrz6XwKw=="
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -44055,43 +46027,10 @@
       }
     },
     "openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "peer": true,
-      "requires": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "dependencies": {
-        "form-data-encoder": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-          "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-          "peer": true
-        },
-        "formdata-node": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-          "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-          "peer": true,
-          "requires": {
-            "node-domexception": "1.0.0",
-            "web-streams-polyfill": "4.0.0-beta.3"
-          }
-        },
-        "web-streams-polyfill": {
-          "version": "4.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-          "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-          "peer": true
-        }
-      }
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "requires": {}
     },
     "openapi-types": {
       "version": "12.1.3",
@@ -44099,12 +46038,12 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
     },
     "openid-client": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.5.0.tgz",
-      "integrity": "sha512-fAfYaTnOYE2kQCqEJGX9KDObW2aw7IQy4jWpU/+3D3WoCFLbix5Hg6qIPQ6Js9r7f8jDUmsnnguRNCSw4wU/IQ==",
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
       "requires": {
-        "jose": "^6.0.10",
-        "oauth4webapi": "^3.5.1"
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
       }
     },
     "option": {
@@ -45388,22 +47327,9 @@
       }
     },
     "semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
-      }
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
     },
     "send": {
       "version": "1.2.0",
@@ -45947,14 +47873,14 @@
       }
     },
     "ssh2": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
-      "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
       "requires": {
         "asn1": "^0.2.6",
         "bcrypt-pbkdf": "^1.0.2",
-        "cpu-features": "~0.0.9",
-        "nan": "^2.18.0"
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "ssh2-sftp-client": {
@@ -45964,19 +47890,6 @@
       "requires": {
         "concat-stream": "^2.0.0",
         "ssh2": "^1.16.0"
-      },
-      "dependencies": {
-        "ssh2": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
-          "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
-          "requires": {
-            "asn1": "^0.2.6",
-            "bcrypt-pbkdf": "^1.0.2",
-            "cpu-features": "~0.0.10",
-            "nan": "^2.23.0"
-          }
-        }
       }
     },
     "sshpk": {
@@ -46132,28 +48045,29 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       }
     },
     "string.prototype.trimstart": {
@@ -46314,9 +48228,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -46617,14 +48531,15 @@
       }
     },
     "thrift": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.21.0.tgz",
-      "integrity": "sha512-AW8rwHYjeqXisS8B1iwko2gkNMFwSRJ+bO/W0xTGqRspTD3lGHwZx438+pHdOJ3GwpRAnK7TKbjqPOrHAa7ZwQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.23.0.tgz",
+      "integrity": "sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==",
       "requires": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
         "q": "^1.5.0",
+        "uuid": "^13.0.0",
         "ws": "^5.2.3"
       },
       "dependencies": {
@@ -46633,6 +48548,11 @@
           "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
           "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
           "requires": {}
+        },
+        "uuid": {
+          "version": "13.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+          "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="
         },
         "ws": {
           "version": "5.2.5",
@@ -46658,9 +48578,9 @@
       "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA=="
     },
     "tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="
     },
     "tmp-promise": {
       "version": "3.0.3",
@@ -46765,14 +48685,6 @@
       "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="
     },
-    "ts-ics": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-ics/-/ts-ics-1.2.2.tgz",
-      "integrity": "sha512-L7T5JQi99qQ2Uv7AoCHUZ8Mx1bJYo7qBZtBckuHueR90I3WVdW5NC/tOqTVgu18c3zj08du+xlgWlTIcE+Foxw==",
-      "requires": {
-        "date-fns-tz": "^2.0.0"
-      }
-    },
     "ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -46819,16 +48731,6 @@
       "requires": {
         "@mixmark-io/domino": "^2.2.0"
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
-    "tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "type-detect": {
       "version": "4.1.0",
@@ -46902,16 +48804,16 @@
       }
     },
     "typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "requires": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       }
     },
     "typedarray": {
@@ -47144,9 +49046,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utilium": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/utilium/-/utilium-1.10.1.tgz",
-      "integrity": "sha512-GQINDTb/ocyz4acQj3GXAe0wipYxws6L+9ouqaq10KlInTk9DGvW9TJd0pYa/Xu3cppNnZuB4T/sBuSXpcN2ng==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/utilium/-/utilium-3.2.0.tgz",
+      "integrity": "sha512-+3bEeQPKMWRIlT9/lXXCzMoVzZt9eU9DAZ4Avi2YeXrO/Ur7O7dEW8seCz0tchSatCVnvKZ+Nd70q7X3CK/OFw==",
       "requires": {
         "@xterm/xterm": "^5.5.0",
         "eventemitter3": "^5.0.1"
@@ -47342,9 +49244,9 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "requires": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.9",
@@ -47691,9 +49593,9 @@
       }
     },
     "zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     },
     "zod-from-json-schema-v3": {
       "version": "npm:zod-from-json-schema@0.0.5",
@@ -47701,12 +49603,19 @@
       "integrity": "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==",
       "requires": {
         "zod": "^3.24.2"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "3.25.76",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+          "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+        }
       }
     },
     "zod-to-json-schema": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
-      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "requires": {}
     },
     "zwitch": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "n8n": "^2.22.4"
+    "n8n": "^2.25.7"
   },
   "engines": {
     "node": "24"


### PR DESCRIPTION
  Updates n8n to the latest stable release: `2.25.7`

  This workflow ran:
  - `npm update n8n`
  - `npm install`
  - `npm ci`
